### PR TITLE
Rename Approvals to URLs and add edit feature to all entities

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -128,7 +128,11 @@ func (h *Handler) deleteApproval(w http.ResponseWriter, r *http.Request) {
 // --- Skills ---
 
 func (h *Handler) listSkills(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, h.Skills.ListSkills())
+	skills := h.Skills.ListSkills()
+	for i := range skills {
+		skills[i].Token = "********"
+	}
+	writeJSON(w, http.StatusOK, skills)
 }
 
 type createSkillRequest struct {
@@ -172,11 +176,20 @@ func (h *Handler) updateSkill(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
+	// Always preserve the existing token (never exposed via API).
+	existing, ok := h.Skills.GetSkill(skill.ID)
+	if !ok {
+		http.Error(w, fmt.Sprintf("skill %q not found", skill.ID), http.StatusNotFound)
+		return
+	}
+	skill.Token = existing.Token
 	if err := h.Skills.UpdateSkill(skill); err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
 	h.save()
+	// Return masked token.
+	skill.Token = "********"
 	writeJSON(w, http.StatusOK, skill)
 }
 
@@ -237,6 +250,27 @@ func (h *Handler) updateCredential(w http.ResponseWriter, r *http.Request) {
 	if err := readJSON(r, &cred); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
+	}
+	// Preserve existing secret values when empty (secrets are never exposed via API).
+	if existing, ok := h.Credentials.Get(cred.ID); ok {
+		switch cred.InjectionType {
+		case credentials.InjectHeader:
+			if cred.HeaderValue == "" {
+				cred.HeaderValue = existing.HeaderValue
+			}
+		case credentials.InjectBasic:
+			if cred.Password == "" {
+				cred.Password = existing.Password
+			}
+		case credentials.InjectBearer:
+			if cred.Token == "" {
+				cred.Token = existing.Token
+			}
+		case credentials.InjectQuery:
+			if cred.ParamValue == "" {
+				cred.ParamValue = existing.ParamValue
+			}
+		}
 	}
 	if err := h.Credentials.Update(cred); err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -66,7 +66,7 @@ func TestSkills_CRUD(t *testing.T) {
 		t.Error("created skill should have a token")
 	}
 
-	// List.
+	// List (tokens should be masked).
 	w = doRequest(mux, "GET", "/api/skills", nil)
 	if w.Code != http.StatusOK {
 		t.Fatalf("list: expected 200, got %d", w.Code)
@@ -76,9 +76,13 @@ func TestSkills_CRUD(t *testing.T) {
 	if len(skills) != 1 {
 		t.Fatalf("expected 1 skill, got %d", len(skills))
 	}
+	if skills[0].Token != "********" {
+		t.Error("token should be masked in list response")
+	}
 
-	// Update.
+	// Update (token preserved even though masked in request).
 	skill.Name = "Updated"
+	skill.Token = "********"
 	w = doRequest(mux, "PUT", "/api/skills", skill)
 	if w.Code != http.StatusOK {
 		t.Fatalf("update: expected 200, got %d: %s", w.Code, w.Body.String())

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -60,6 +60,18 @@ func (s *SkillStore) AddSkill(skill Skill) error {
 	return nil
 }
  
+// GetSkill returns a skill by ID.
+func (s *SkillStore) GetSkill(id string) (*Skill, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	skill, ok := s.byID[id]
+	if !ok {
+		return nil, false
+	}
+	cp := *skill
+	return &cp, true
+}
+
 // UpdateSkill updates an existing skill.
 func (s *SkillStore) UpdateSkill(skill Skill) error {
 	s.mu.Lock()

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -54,6 +54,18 @@ func (m *Manager) Add(c Credential) {
 	m.creds[c.ID] = &c
 }
  
+// Get returns a credential by ID.
+func (m *Manager) Get(id string) (*Credential, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	c, ok := m.creds[id]
+	if !ok {
+		return nil, false
+	}
+	cp := *c
+	return &cp, true
+}
+
 // Update replaces a credential by ID.
 func (m *Manager) Update(c Credential) error {
 	m.mu.Lock()

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -3,6 +3,18 @@ const API = '';
 let pollInterval = null;
 let lastLogID = 0;
 
+// Edit state trackers
+let editingRule = null;       // null = adding, { host, pathPrefix, skillID, sourceIP } = editing
+let editingImageRule = null;  // null = adding, { host, skillID, sourceIP } = editing
+let editingSkillID = null;    // null = creating, string = editing
+let editingCredID = null;     // null = creating, string = editing
+
+// Cached data for edit lookups
+let currentApprovals = [];
+let currentImages = [];
+let currentSkills = [];
+let currentCredentials = [];
+
 // --- Navigation ---
 function navigate(page) {
   document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));
@@ -125,11 +137,12 @@ async function decideDash(apiPath, host, skillID, sourceIP, pathPrefix, status) 
   }
 }
 
-// --- Approvals ---
+// --- URL Rules (Approvals) ---
 async function loadApprovals() {
   try {
     const approvals = await api('GET', '/api/approvals');
-    const pending = (approvals || []).filter(a => a.status === 'pending');
+    currentApprovals = approvals || [];
+    const pending = currentApprovals.filter(a => a.status === 'pending');
     const badge = document.getElementById('approval-badge');
     if (pending.length > 0) {
       badge.textContent = pending.length;
@@ -139,19 +152,20 @@ async function loadApprovals() {
     }
     const tbody = document.getElementById('approvals-tbody');
     tbody.innerHTML = '';
-    if (!approvals || approvals.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="7" class="empty-state">No approval records</td></tr>';
+    if (currentApprovals.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="7" class="empty-state">No URL rules</td></tr>';
       return;
     }
-    approvals.sort((a, b) => {
+    currentApprovals.sort((a, b) => {
       const order = { pending: 0, approved: 1, denied: 2 };
       return (order[a.status] || 9) - (order[b.status] || 9);
     });
-    approvals.forEach(a => {
+    currentApprovals.forEach((a, idx) => {
       const skillDisplay = formatSkillID(a.skill_id);
       const sourceDisplay = formatSourceIP(a.source_ip);
       const pathDisplay = formatPathPrefix(a.path_prefix);
       const pp = a.path_prefix || '';
+      const editBtn = `<button class="btn btn-outline btn-sm" onclick="showEditRule(${idx})" title="Edit rule">Edit</button>`;
       const deleteBtn = `<button class="btn btn-danger btn-sm" onclick="deleteApproval('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','${esc(pp)}')" title="Delete rule">Delete</button>`;
       let actions = '';
       if (a.status === 'pending') {
@@ -162,14 +176,14 @@ async function loadApprovals() {
         actions = `<button class="btn btn-success btn-sm" onclick="decide('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','${esc(pp)}','approved')">Approve</button>
            ${vmBtn} ${globalBtn}
            <button class="btn btn-danger btn-sm" onclick="decide('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','${esc(pp)}','denied')">Deny</button>
-           ${deleteBtn}`;
+           ${editBtn} ${deleteBtn}`;
       } else {
         const promoteBtn = a.source_ip && !a.skill_id
           ? `<button class="btn btn-outline btn-sm" onclick="promoteToGlobal('${esc(a.host)}','${esc(a.source_ip)}','${esc(pp)}','${a.status}')" title="Promote to global rule">Promote to Global</button>` : '';
         actions = `<button class="btn btn-outline btn-sm" onclick="decide('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','${esc(pp)}','approved')">Approve</button>
            <button class="btn btn-outline btn-sm" onclick="decide('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','${esc(pp)}','denied')">Deny</button>
            ${promoteBtn}
-           ${deleteBtn}`;
+           ${editBtn} ${deleteBtn}`;
       }
       tbody.innerHTML += `<tr>
         <td><strong>${esc(a.host)}</strong></td>
@@ -182,14 +196,13 @@ async function loadApprovals() {
       </tr>`;
     });
   } catch (e) {
-    console.error('Approvals load error:', e);
+    console.error('URL rules load error:', e);
   }
 }
 
 async function decide(host, skillID, sourceIP, pathPrefix, status) {
   try {
     await api('POST', '/api/approvals/decide', { host, skill_id: skillID, source_ip: sourceIP, path_prefix: pathPrefix, status });
-    // Refresh current page
     const activePage = document.querySelector('.page.active');
     if (activePage) {
       const pageId = activePage.id.replace('page-', '');
@@ -228,28 +241,58 @@ async function promoteToGlobal(host, sourceIP, pathPrefix, status) {
   }
 }
 
-// --- Add Rule (proactive approval) ---
+// --- URL Rule Modal ---
 function showAddRule() {
-  document.getElementById('modal-rule').classList.add('active');
-  updateRuleFields();
-}
-function hideAddRule() {
-  document.getElementById('modal-rule').classList.remove('active');
+  editingRule = null;
+  document.getElementById('modal-rule-title').textContent = 'Add URL Rule';
+  document.getElementById('modal-rule-submit').textContent = 'Add Rule';
   document.getElementById('rule-host').value = '';
   document.getElementById('rule-path-prefix').value = '';
   document.getElementById('rule-level').value = 'global';
   document.getElementById('rule-source-ip').value = '';
+  document.getElementById('rule-skill-id').value = '';
   document.getElementById('rule-status').value = 'approved';
   document.getElementById('rule-note').value = '';
   updateRuleFields();
+  document.getElementById('modal-rule').classList.add('active');
+}
+
+function showEditRule(idx) {
+  const a = currentApprovals[idx];
+  if (!a) return;
+  editingRule = { host: a.host, pathPrefix: a.path_prefix || '', skillID: a.skill_id || '', sourceIP: a.source_ip || '' };
+  document.getElementById('modal-rule-title').textContent = 'Edit URL Rule';
+  document.getElementById('modal-rule-submit').textContent = 'Save';
+  document.getElementById('rule-host').value = a.host;
+  document.getElementById('rule-path-prefix').value = a.path_prefix || '';
+  if (a.skill_id) {
+    document.getElementById('rule-level').value = 'skill';
+    document.getElementById('rule-skill-id').value = a.skill_id;
+    document.getElementById('rule-source-ip').value = a.source_ip || '';
+  } else if (a.source_ip) {
+    document.getElementById('rule-level').value = 'vm';
+    document.getElementById('rule-source-ip').value = a.source_ip;
+  } else {
+    document.getElementById('rule-level').value = 'global';
+  }
+  document.getElementById('rule-status').value = a.status === 'pending' ? 'approved' : a.status;
+  document.getElementById('rule-note').value = a.note || '';
+  updateRuleFields();
+  document.getElementById('modal-rule').classList.add('active');
+}
+
+function hideAddRule() {
+  document.getElementById('modal-rule').classList.remove('active');
+  editingRule = null;
 }
 
 function updateRuleFields() {
   const level = document.getElementById('rule-level').value;
-  document.getElementById('rule-vm-fields').style.display = level === 'vm' ? 'block' : 'none';
+  document.getElementById('rule-vm-fields').style.display = (level === 'vm' || level === 'skill') ? 'block' : 'none';
+  document.getElementById('rule-skill-fields').style.display = level === 'skill' ? 'block' : 'none';
 }
 
-async function addRule() {
+async function submitRule() {
   const host = document.getElementById('rule-host').value.trim();
   if (!host) { alert('Host pattern is required'); return; }
   const pathPrefix = document.getElementById('rule-path-prefix').value.trim();
@@ -257,12 +300,32 @@ async function addRule() {
   const status = document.getElementById('rule-status').value;
   const note = document.getElementById('rule-note').value.trim();
   let sourceIP = '';
-  if (level === 'vm') {
+  let skillID = '';
+  if (level === 'vm' || level === 'skill') {
     sourceIP = document.getElementById('rule-source-ip').value.trim();
-    if (!sourceIP) { alert('Source IP is required for VM-specific rules'); return; }
+  }
+  if (level === 'skill') {
+    skillID = document.getElementById('rule-skill-id').value.trim();
+    if (!skillID) { alert('Skill ID is required for skill-specific rules'); return; }
+  }
+  if (level === 'vm' && !sourceIP) {
+    alert('Source IP is required for VM-specific rules'); return;
   }
   try {
-    await api('POST', '/api/approvals/decide', { host, skill_id: '', source_ip: sourceIP, path_prefix: pathPrefix, status, note });
+    // If editing and key fields changed, delete the old rule first.
+    if (editingRule) {
+      const keyChanged = editingRule.host !== host ||
+        editingRule.pathPrefix !== pathPrefix ||
+        editingRule.skillID !== skillID ||
+        editingRule.sourceIP !== sourceIP;
+      if (keyChanged) {
+        await api('DELETE', '/api/approvals', {
+          host: editingRule.host, skill_id: editingRule.skillID,
+          source_ip: editingRule.sourceIP, path_prefix: editingRule.pathPrefix,
+        });
+      }
+    }
+    await api('POST', '/api/approvals/decide', { host, skill_id: skillID, source_ip: sourceIP, path_prefix: pathPrefix, status, note });
     hideAddRule();
     loadApprovals();
   } catch (e) {
@@ -274,7 +337,8 @@ async function addRule() {
 async function loadImages() {
   try {
     const images = await api('GET', '/api/images');
-    const pending = (images || []).filter(a => a.status === 'pending');
+    currentImages = images || [];
+    const pending = currentImages.filter(a => a.status === 'pending');
     const badge = document.getElementById('image-badge');
     if (pending.length > 0) {
       badge.textContent = pending.length;
@@ -284,17 +348,18 @@ async function loadImages() {
     }
     const tbody = document.getElementById('images-tbody');
     tbody.innerHTML = '';
-    if (!images || images.length === 0) {
+    if (currentImages.length === 0) {
       tbody.innerHTML = '<tr><td colspan="6" class="empty-state">No image approval records</td></tr>';
       return;
     }
-    images.sort((a, b) => {
+    currentImages.sort((a, b) => {
       const order = { pending: 0, approved: 1, denied: 2 };
       return (order[a.status] || 9) - (order[b.status] || 9);
     });
-    images.forEach(a => {
+    currentImages.forEach((a, idx) => {
       const skillDisplay = formatSkillID(a.skill_id);
       const sourceDisplay = formatSourceIP(a.source_ip);
+      const editBtn = `<button class="btn btn-outline btn-sm" onclick="showEditImageRule(${idx})" title="Edit rule">Edit</button>`;
       const deleteBtn = `<button class="btn btn-danger btn-sm" onclick="deleteImage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}')" title="Delete rule">Delete</button>`;
       let actions = '';
       if (a.status === 'pending') {
@@ -305,14 +370,14 @@ async function loadImages() {
         actions = `<button class="btn btn-success btn-sm" onclick="decideImage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','approved')">Approve</button>
            ${vmBtn} ${globalBtn}
            <button class="btn btn-danger btn-sm" onclick="decideImage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','denied')">Deny</button>
-           ${deleteBtn}`;
+           ${editBtn} ${deleteBtn}`;
       } else {
         const promoteBtn = a.source_ip && !a.skill_id
           ? `<button class="btn btn-outline btn-sm" onclick="promoteImageToGlobal('${esc(a.host)}','${esc(a.source_ip)}','${a.status}')" title="Promote to global rule">Promote to Global</button>` : '';
         actions = `<button class="btn btn-outline btn-sm" onclick="decideImage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','approved')">Approve</button>
            <button class="btn btn-outline btn-sm" onclick="decideImage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','denied')">Deny</button>
            ${promoteBtn}
-           ${deleteBtn}`;
+           ${editBtn} ${deleteBtn}`;
       }
       tbody.innerHTML += `<tr>
         <td><strong>${esc(a.host)}</strong></td>
@@ -369,19 +434,42 @@ async function promoteImageToGlobal(host, sourceIP, status) {
   }
 }
 
-// --- Add Image Rule ---
+// --- Image Rule Modal ---
 function showAddImageRule() {
-  document.getElementById('modal-image-rule').classList.add('active');
-  updateImageRuleFields();
-}
-function hideAddImageRule() {
-  document.getElementById('modal-image-rule').classList.remove('active');
+  editingImageRule = null;
+  document.getElementById('modal-image-title').textContent = 'Add Image Approval Rule';
+  document.getElementById('modal-image-submit').textContent = 'Add Rule';
   document.getElementById('image-rule-host').value = '';
   document.getElementById('image-rule-level').value = 'global';
   document.getElementById('image-rule-source-ip').value = '';
   document.getElementById('image-rule-status').value = 'approved';
   document.getElementById('image-rule-note').value = '';
   updateImageRuleFields();
+  document.getElementById('modal-image-rule').classList.add('active');
+}
+
+function showEditImageRule(idx) {
+  const a = currentImages[idx];
+  if (!a) return;
+  editingImageRule = { host: a.host, skillID: a.skill_id || '', sourceIP: a.source_ip || '' };
+  document.getElementById('modal-image-title').textContent = 'Edit Image Approval Rule';
+  document.getElementById('modal-image-submit').textContent = 'Save';
+  document.getElementById('image-rule-host').value = a.host;
+  if (a.source_ip) {
+    document.getElementById('image-rule-level').value = 'vm';
+    document.getElementById('image-rule-source-ip').value = a.source_ip;
+  } else {
+    document.getElementById('image-rule-level').value = 'global';
+  }
+  document.getElementById('image-rule-status').value = a.status === 'pending' ? 'approved' : a.status;
+  document.getElementById('image-rule-note').value = a.note || '';
+  updateImageRuleFields();
+  document.getElementById('modal-image-rule').classList.add('active');
+}
+
+function hideImageRuleModal() {
+  document.getElementById('modal-image-rule').classList.remove('active');
+  editingImageRule = null;
 }
 
 function updateImageRuleFields() {
@@ -389,7 +477,7 @@ function updateImageRuleFields() {
   document.getElementById('image-rule-vm-fields').style.display = level === 'vm' ? 'block' : 'none';
 }
 
-async function addImageRule() {
+async function submitImageRule() {
   const host = document.getElementById('image-rule-host').value.trim();
   if (!host) { alert('Image pattern is required'); return; }
   const level = document.getElementById('image-rule-level').value;
@@ -401,8 +489,18 @@ async function addImageRule() {
     if (!sourceIP) { alert('Source IP is required for VM-specific rules'); return; }
   }
   try {
+    if (editingImageRule) {
+      const keyChanged = editingImageRule.host !== host ||
+        editingImageRule.sourceIP !== sourceIP;
+      if (keyChanged) {
+        await api('DELETE', '/api/images', {
+          host: editingImageRule.host, skill_id: editingImageRule.skillID,
+          source_ip: editingImageRule.sourceIP,
+        });
+      }
+    }
     await api('POST', '/api/images/decide', { host, skill_id: '', source_ip: sourceIP, status, note });
-    hideAddImageRule();
+    hideImageRuleModal();
     loadImages();
   } catch (e) {
     alert('Error: ' + e.message);
@@ -413,21 +511,22 @@ async function addImageRule() {
 async function loadSkills() {
   try {
     const skills = await api('GET', '/api/skills');
+    currentSkills = skills || [];
     const tbody = document.getElementById('skills-tbody');
     tbody.innerHTML = '';
-    if (!skills || skills.length === 0) {
+    if (currentSkills.length === 0) {
       tbody.innerHTML = '<tr><td colspan="5" class="empty-state">No skills configured. Create one to get started.</td></tr>';
       return;
     }
-    skills.forEach(s => {
+    currentSkills.forEach((s, idx) => {
       tbody.innerHTML += `<tr>
         <td><strong>${esc(s.id)}</strong></td>
         <td>${esc(s.name)}</td>
-        <td><div class="token-display" onclick="copyToken(this)" title="Click to copy">${esc(s.token)}</div></td>
         <td>${(s.allowed_hosts || []).map(h => `<span class="badge-status approved">${esc(h)}</span>`).join(' ') || '<span class="badge-status denied">none</span>'}</td>
+        <td><span class="badge-status ${s.active ? 'approved' : 'denied'}">${s.active ? 'active' : 'inactive'}</span></td>
         <td>
-          <span class="badge-status ${s.active ? 'approved' : 'denied'}">${s.active ? 'active' : 'inactive'}</span>
-          <button class="btn btn-danger btn-sm" onclick="deleteSkill('${esc(s.id)}')" style="margin-left:8px">Delete</button>
+          <button class="btn btn-outline btn-sm" onclick="showEditSkill(${idx})">Edit</button>
+          <button class="btn btn-danger btn-sm" onclick="deleteSkill('${esc(s.id)}')">Delete</button>
         </td>
       </tr>`;
     });
@@ -437,10 +536,45 @@ async function loadSkills() {
 }
 
 function showCreateSkill() {
+  editingSkillID = null;
+  document.getElementById('modal-skill-title').textContent = 'Create Skill';
+  document.getElementById('modal-skill-submit').textContent = 'Create';
+  document.getElementById('skill-id').value = '';
+  document.getElementById('skill-id').readOnly = false;
+  document.getElementById('skill-id-group').querySelector('label').textContent = 'Skill ID (optional, auto-generated if empty)';
+  document.getElementById('skill-name').value = '';
+  document.getElementById('skill-hosts').value = '';
+  document.getElementById('skill-active-group').style.display = 'none';
   document.getElementById('modal-skill').classList.add('active');
 }
-function hideCreateSkill() {
+
+function showEditSkill(idx) {
+  const s = currentSkills[idx];
+  if (!s) return;
+  editingSkillID = s.id;
+  document.getElementById('modal-skill-title').textContent = 'Edit Skill';
+  document.getElementById('modal-skill-submit').textContent = 'Save';
+  document.getElementById('skill-id').value = s.id;
+  document.getElementById('skill-id').readOnly = true;
+  document.getElementById('skill-id-group').querySelector('label').textContent = 'Skill ID (read-only)';
+  document.getElementById('skill-name').value = s.name;
+  document.getElementById('skill-hosts').value = (s.allowed_hosts || []).join('\n');
+  document.getElementById('skill-active-group').style.display = 'block';
+  document.getElementById('skill-active').value = s.active ? 'true' : 'false';
+  document.getElementById('modal-skill').classList.add('active');
+}
+
+function hideSkillModal() {
   document.getElementById('modal-skill').classList.remove('active');
+  editingSkillID = null;
+}
+
+async function submitSkill() {
+  if (editingSkillID) {
+    await updateSkill();
+  } else {
+    await createSkill();
+  }
 }
 
 async function createSkill() {
@@ -452,12 +586,24 @@ async function createSkill() {
     const body = { name, allowed_hosts: hosts };
     if (id) body.id = id;
     const result = await api('POST', '/api/skills', body);
-    hideCreateSkill();
-    document.getElementById('skill-id').value = '';
-    document.getElementById('skill-name').value = '';
-    document.getElementById('skill-hosts').value = '';
+    hideSkillModal();
     loadSkills();
     alert('Skill created!\n\nID: ' + result.id + '\nToken: ' + result.token);
+  } catch (e) {
+    alert('Error: ' + e.message);
+  }
+}
+
+async function updateSkill() {
+  const id = editingSkillID;
+  const name = document.getElementById('skill-name').value.trim();
+  const hosts = document.getElementById('skill-hosts').value.trim().split(/[\n,]+/).map(h => h.trim()).filter(Boolean);
+  const active = document.getElementById('skill-active').value === 'true';
+  if (!name) { alert('Name is required'); return; }
+  try {
+    await api('PUT', '/api/skills', { id, name, allowed_hosts: hosts, active, token: '' });
+    hideSkillModal();
+    loadSkills();
   } catch (e) {
     alert('Error: ' + e.message);
   }
@@ -484,20 +630,24 @@ function copyToken(el) {
 async function loadCredentials() {
   try {
     const creds = await api('GET', '/api/credentials');
+    currentCredentials = creds || [];
     const tbody = document.getElementById('credentials-tbody');
     tbody.innerHTML = '';
-    if (!creds || creds.length === 0) {
+    if (currentCredentials.length === 0) {
       tbody.innerHTML = '<tr><td colspan="6" class="empty-state">No credentials configured.</td></tr>';
       return;
     }
-    creds.forEach(c => {
+    currentCredentials.forEach((c, idx) => {
       tbody.innerHTML += `<tr>
         <td><strong>${esc(c.name)}</strong></td>
         <td>${esc(c.host_pattern)}</td>
         <td>${formatSkillID(c.skill_id)}</td>
         <td><span class="badge-status approved">${esc(c.injection_type)}</span></td>
         <td><span class="badge-status ${c.active ? 'approved' : 'denied'}">${c.active ? 'active' : 'inactive'}</span></td>
-        <td><button class="btn btn-danger btn-sm" onclick="deleteCredential('${esc(c.id)}')">Delete</button></td>
+        <td>
+          <button class="btn btn-outline btn-sm" onclick="showEditCred(${idx})">Edit</button>
+          <button class="btn btn-danger btn-sm" onclick="deleteCredential('${esc(c.id)}')">Delete</button>
+        </td>
       </tr>`;
     });
   } catch (e) {
@@ -506,11 +656,62 @@ async function loadCredentials() {
 }
 
 function showCreateCred() {
-  document.getElementById('modal-cred').classList.add('active');
+  editingCredID = null;
+  document.getElementById('modal-cred-title').textContent = 'Add Credential';
+  document.getElementById('modal-cred-submit').textContent = 'Add';
+  document.getElementById('cred-name').value = '';
+  document.getElementById('cred-host').value = '';
+  document.getElementById('cred-skill').value = '';
+  document.getElementById('cred-type').value = 'header';
+  document.getElementById('cred-header-name').value = '';
+  document.getElementById('cred-header-value').value = '';
+  document.getElementById('cred-header-value').placeholder = 'secret value';
+  document.getElementById('cred-username').value = '';
+  document.getElementById('cred-password').value = '';
+  document.getElementById('cred-password').placeholder = '';
+  document.getElementById('cred-bearer-token').value = '';
+  document.getElementById('cred-bearer-token').placeholder = '';
+  document.getElementById('cred-param-name').value = '';
+  document.getElementById('cred-param-value').value = '';
+  document.getElementById('cred-param-value').placeholder = '';
+  document.getElementById('cred-active-group').style.display = 'none';
   updateCredFields();
+  document.getElementById('modal-cred').classList.add('active');
 }
-function hideCreateCred() {
+
+function showEditCred(idx) {
+  const c = currentCredentials[idx];
+  if (!c) return;
+  editingCredID = c.id;
+  document.getElementById('modal-cred-title').textContent = 'Edit Credential';
+  document.getElementById('modal-cred-submit').textContent = 'Save';
+  document.getElementById('cred-name').value = c.name;
+  document.getElementById('cred-host').value = c.host_pattern;
+  document.getElementById('cred-skill').value = c.skill_id || '';
+  document.getElementById('cred-type').value = c.injection_type;
+  // Non-secret fields
+  document.getElementById('cred-header-name').value = c.header_name || '';
+  document.getElementById('cred-username').value = c.username || '';
+  document.getElementById('cred-param-name').value = c.param_name || '';
+  // Secret fields: leave empty, show placeholder
+  document.getElementById('cred-header-value').value = '';
+  document.getElementById('cred-header-value').placeholder = 'leave empty to keep current value';
+  document.getElementById('cred-password').value = '';
+  document.getElementById('cred-password').placeholder = 'leave empty to keep current value';
+  document.getElementById('cred-bearer-token').value = '';
+  document.getElementById('cred-bearer-token').placeholder = 'leave empty to keep current value';
+  document.getElementById('cred-param-value').value = '';
+  document.getElementById('cred-param-value').placeholder = 'leave empty to keep current value';
+  // Show active toggle
+  document.getElementById('cred-active-group').style.display = 'block';
+  document.getElementById('cred-active').value = c.active ? 'true' : 'false';
+  updateCredFields();
+  document.getElementById('modal-cred').classList.add('active');
+}
+
+function hideCredModal() {
   document.getElementById('modal-cred').classList.remove('active');
+  editingCredID = null;
 }
 
 function updateCredFields() {
@@ -519,6 +720,14 @@ function updateCredFields() {
   document.getElementById('cred-basic-fields').style.display = type === 'basic_auth' ? 'block' : 'none';
   document.getElementById('cred-bearer-fields').style.display = type === 'bearer' ? 'block' : 'none';
   document.getElementById('cred-query-fields').style.display = type === 'query_param' ? 'block' : 'none';
+}
+
+async function submitCredential() {
+  if (editingCredID) {
+    await updateCredential();
+  } else {
+    await createCredential();
+  }
 }
 
 async function createCredential() {
@@ -545,7 +754,40 @@ async function createCredential() {
   }
   try {
     await api('POST', '/api/credentials', cred);
-    hideCreateCred();
+    hideCredModal();
+    loadCredentials();
+  } catch (e) {
+    alert('Error: ' + e.message);
+  }
+}
+
+async function updateCredential() {
+  const type = document.getElementById('cred-type').value;
+  const cred = {
+    id: editingCredID,
+    name: document.getElementById('cred-name').value.trim(),
+    host_pattern: document.getElementById('cred-host').value.trim(),
+    skill_id: document.getElementById('cred-skill').value.trim(),
+    injection_type: type,
+    active: document.getElementById('cred-active').value === 'true',
+  };
+  if (!cred.name || !cred.host_pattern) { alert('Name and host pattern are required'); return; }
+  // Only send secret fields if user entered a new value (empty = keep current on backend).
+  if (type === 'header') {
+    cred.header_name = document.getElementById('cred-header-name').value.trim();
+    cred.header_value = document.getElementById('cred-header-value').value;
+  } else if (type === 'basic_auth') {
+    cred.username = document.getElementById('cred-username').value.trim();
+    cred.password = document.getElementById('cred-password').value;
+  } else if (type === 'bearer') {
+    cred.token = document.getElementById('cred-bearer-token').value;
+  } else if (type === 'query_param') {
+    cred.param_name = document.getElementById('cred-param-name').value.trim();
+    cred.param_value = document.getElementById('cred-param-value').value;
+  }
+  try {
+    await api('PUT', '/api/credentials', cred);
+    hideCredModal();
     loadCredentials();
   } catch (e) {
     alert('Error: ' + e.message);

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -13,7 +13,7 @@
       <h1><span class="logo">&#x1f6e1;</span> Firewall4AI</h1>
       <nav>
         <a href="#" data-page="dashboard" class="active">&#x25a0; Dashboard</a>
-        <a href="#" data-page="approvals">&#x2714; Approvals <span id="approval-badge" class="badge" style="display:none">0</span></a>
+        <a href="#" data-page="approvals">&#x2714; URLs <span id="approval-badge" class="badge" style="display:none">0</span></a>
         <a href="#" data-page="images">&#x1f4e6; Images <span id="image-badge" class="badge" style="display:none">0</span></a>
         <a href="#" data-page="skills">&#x26a1; Skills</a>
         <a href="#" data-page="credentials">&#x1f511; Credentials</a>
@@ -46,17 +46,17 @@
         </div>
       </div>
 
-      <!-- Approvals -->
+      <!-- URLs -->
       <div id="page-approvals" class="page">
         <div class="toolbar">
-          <h2>Host Approvals</h2>
+          <h2>URL Rules</h2>
           <button class="btn btn-primary" onclick="showAddRule()">+ Add Rule</button>
         </div>
         <div class="card">
           <table>
             <thead><tr><th>Host</th><th>Path Prefix</th><th>Skill</th><th>Source IP</th><th>Status</th><th>Updated</th><th>Actions</th></tr></thead>
             <tbody id="approvals-tbody">
-              <tr><td colspan="7" class="empty-state">No approval records</td></tr>
+              <tr><td colspan="7" class="empty-state">No URL rules</td></tr>
             </tbody>
           </table>
         </div>
@@ -86,7 +86,7 @@
         </div>
         <div class="card">
           <table>
-            <thead><tr><th>ID</th><th>Name</th><th>Token</th><th>Pre-approved Hosts</th><th>Status</th></tr></thead>
+            <thead><tr><th>ID</th><th>Name</th><th>Pre-approved Hosts</th><th>Status</th><th>Actions</th></tr></thead>
             <tbody id="skills-tbody">
               <tr><td colspan="5" class="empty-state">No skills configured. Create one to get started.</td></tr>
             </tbody>
@@ -127,10 +127,10 @@
     </main>
   </div>
 
-  <!-- Add Rule Modal -->
+  <!-- URL Rule Modal -->
   <div id="modal-rule" class="modal-overlay">
     <div class="modal">
-      <h3>Add Approval Rule</h3>
+      <h3 id="modal-rule-title">Add URL Rule</h3>
       <div class="form-group">
         <label>Host Pattern (supports wildcards like *.example.com)</label>
         <input type="text" id="rule-host" placeholder="e.g., api.example.com or *.example.com">
@@ -144,12 +144,19 @@
         <select id="rule-level" onchange="updateRuleFields()">
           <option value="global">Global (all agents, all VMs)</option>
           <option value="vm">VM-specific (by source IP)</option>
+          <option value="skill">Skill-specific (by skill ID)</option>
         </select>
       </div>
       <div id="rule-vm-fields" style="display:none">
         <div class="form-group">
           <label>Source IP</label>
           <input type="text" id="rule-source-ip" placeholder="e.g., 10.255.255.10">
+        </div>
+      </div>
+      <div id="rule-skill-fields" style="display:none">
+        <div class="form-group">
+          <label>Skill ID</label>
+          <input type="text" id="rule-skill-id" placeholder="e.g., a1b2c3d4-e5f6-4789-abcd-ef0123456789">
         </div>
       </div>
       <div class="form-group">
@@ -165,16 +172,16 @@
       </div>
       <div class="modal-actions">
         <button class="btn btn-outline" onclick="hideAddRule()">Cancel</button>
-        <button class="btn btn-primary" onclick="addRule()">Add Rule</button>
+        <button class="btn btn-primary" id="modal-rule-submit" onclick="submitRule()">Add Rule</button>
       </div>
     </div>
   </div>
 
-  <!-- Create Skill Modal -->
+  <!-- Skill Modal -->
   <div id="modal-skill" class="modal-overlay">
     <div class="modal">
-      <h3>Create Skill</h3>
-      <div class="form-group">
+      <h3 id="modal-skill-title">Create Skill</h3>
+      <div class="form-group" id="skill-id-group">
         <label>Skill ID (optional, auto-generated if empty)</label>
         <input type="text" id="skill-id" placeholder="auto-generated GUID if left empty">
       </div>
@@ -186,17 +193,24 @@
         <label>Pre-approved Hosts (one per line, supports wildcards like *.example.com)</label>
         <textarea id="skill-hosts" rows="3" placeholder="api.example.com&#10;*.trusted.com"></textarea>
       </div>
+      <div class="form-group" id="skill-active-group" style="display:none">
+        <label>Status</label>
+        <select id="skill-active">
+          <option value="true">Active</option>
+          <option value="false">Inactive</option>
+        </select>
+      </div>
       <div class="modal-actions">
-        <button class="btn btn-outline" onclick="hideCreateSkill()">Cancel</button>
-        <button class="btn btn-primary" onclick="createSkill()">Create</button>
+        <button class="btn btn-outline" onclick="hideSkillModal()">Cancel</button>
+        <button class="btn btn-primary" id="modal-skill-submit" onclick="submitSkill()">Create</button>
       </div>
     </div>
   </div>
 
-  <!-- Create Credential Modal -->
+  <!-- Credential Modal -->
   <div id="modal-cred" class="modal-overlay">
     <div class="modal">
-      <h3>Add Credential</h3>
+      <h3 id="modal-cred-title">Add Credential</h3>
       <div class="form-group">
         <label>Name</label>
         <input type="text" id="cred-name" placeholder="e.g., GitHub API Key">
@@ -225,7 +239,7 @@
           <input type="text" id="cred-header-name" placeholder="e.g., X-API-Key">
         </div>
         <div class="form-group">
-          <label>Header Value</label>
+          <label id="cred-header-value-label">Header Value</label>
           <input type="password" id="cred-header-value" placeholder="secret value">
         </div>
       </div>
@@ -236,14 +250,14 @@
           <input type="text" id="cred-username">
         </div>
         <div class="form-group">
-          <label>Password</label>
+          <label id="cred-password-label">Password</label>
           <input type="password" id="cred-password">
         </div>
       </div>
       <!-- Bearer fields -->
       <div id="cred-bearer-fields" style="display:none">
         <div class="form-group">
-          <label>Bearer Token</label>
+          <label id="cred-bearer-token-label">Bearer Token</label>
           <input type="password" id="cred-bearer-token">
         </div>
       </div>
@@ -254,21 +268,28 @@
           <input type="text" id="cred-param-name" placeholder="e.g., api_key">
         </div>
         <div class="form-group">
-          <label>Parameter Value</label>
+          <label id="cred-param-value-label">Parameter Value</label>
           <input type="password" id="cred-param-value">
         </div>
       </div>
+      <div class="form-group" id="cred-active-group" style="display:none">
+        <label>Status</label>
+        <select id="cred-active">
+          <option value="true">Active</option>
+          <option value="false">Inactive</option>
+        </select>
+      </div>
       <div class="modal-actions">
-        <button class="btn btn-outline" onclick="hideCreateCred()">Cancel</button>
-        <button class="btn btn-primary" onclick="createCredential()">Add</button>
+        <button class="btn btn-outline" onclick="hideCredModal()">Cancel</button>
+        <button class="btn btn-primary" id="modal-cred-submit" onclick="submitCredential()">Add</button>
       </div>
     </div>
   </div>
 
-  <!-- Add Image Rule Modal -->
+  <!-- Image Rule Modal -->
   <div id="modal-image-rule" class="modal-overlay">
     <div class="modal">
-      <h3>Add Image Approval Rule</h3>
+      <h3 id="modal-image-title">Add Image Approval Rule</h3>
       <div class="form-group">
         <label>Repository (e.g., docker.io/library/ubuntu or docker.io/library/*)</label>
         <input type="text" id="image-rule-host" placeholder="e.g., docker.io/library/ubuntu">
@@ -298,8 +319,8 @@
         <input type="text" id="image-rule-note" placeholder="e.g., Allow official Ubuntu images">
       </div>
       <div class="modal-actions">
-        <button class="btn btn-outline" onclick="hideAddImageRule()">Cancel</button>
-        <button class="btn btn-primary" onclick="addImageRule()">Add Rule</button>
+        <button class="btn btn-outline" onclick="hideImageRuleModal()">Cancel</button>
+        <button class="btn btn-primary" id="modal-image-submit" onclick="submitImageRule()">Add Rule</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Rename "Approvals" to "URLs" in sidebar nav, page title, and modals
- Add edit buttons and modals for URLs, Images, Skills, and Credentials
- Mask skill tokens in API list response (only shown at creation time)
- Preserve existing secrets on update (tokens, passwords, API keys)
- Add GetSkill and Get methods to auth and credentials packages
- Add skill-specific level option to URL rule modal
- Add active/inactive toggle to skill and credential edit modals