### PR TITLE
Add configurable logging modes (Normal/Full) to URL rules

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -63,6 +63,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	// Logs
 	mux.HandleFunc("GET /api/logs", h.getLogs)
 	mux.HandleFunc("GET /api/logs/stats", h.getLogStats)
+	mux.HandleFunc("GET /api/logs/detail", h.getLogDetail)
 
 	// Health
 	mux.HandleFunc("GET /api/health", h.health)
@@ -104,13 +105,14 @@ func (h *Handler) listPending(w http.ResponseWriter, r *http.Request) {
 }
 
 type decisionRequest struct {
-	Host       string          `json:"host"`
-	SkillID    string          `json:"skill_id"`
-	SourceIP   string          `json:"source_ip"`
-	PathPrefix string          `json:"path_prefix"`
-	Category   string          `json:"category"`
-	Status     approval.Status `json:"status"`
-	Note       string          `json:"note"`
+	Host        string              `json:"host"`
+	SkillID     string              `json:"skill_id"`
+	SourceIP    string              `json:"source_ip"`
+	PathPrefix  string              `json:"path_prefix"`
+	Category    string              `json:"category"`
+	LoggingMode approval.LoggingMode `json:"logging_mode"`
+	Status      approval.Status     `json:"status"`
+	Note        string              `json:"note"`
 }
 
 func (h *Handler) decideApproval(w http.ResponseWriter, r *http.Request) {
@@ -126,6 +128,9 @@ func (h *Handler) decideApproval(w http.ResponseWriter, r *http.Request) {
 	h.Approvals.Decide(req.Host, req.SkillID, req.SourceIP, req.PathPrefix, req.Status, req.Note)
 	if req.Category != "" {
 		h.Approvals.SetCategory(req.Host, req.SkillID, req.SourceIP, req.PathPrefix, req.Category)
+	}
+	if req.LoggingMode != "" {
+		h.Approvals.SetLoggingMode(req.Host, req.SkillID, req.SourceIP, req.PathPrefix, req.LoggingMode)
 	}
 	h.save()
 	writeJSON(w, http.StatusOK, map[string]string{"result": "ok"})
@@ -416,6 +421,55 @@ func (h *Handler) getLogs(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) getLogStats(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, h.Logger.Stats())
+}
+
+func (h *Handler) getLogDetail(w http.ResponseWriter, r *http.Request) {
+	idStr := r.URL.Query().Get("id")
+	if idStr == "" {
+		http.Error(w, "id parameter required", http.StatusBadRequest)
+		return
+	}
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	entry, ok := h.Logger.GetByID(id)
+	if !ok {
+		http.Error(w, "log entry not found", http.StatusNotFound)
+		return
+	}
+	if entry.FullDetail == nil {
+		http.Error(w, "no full detail available for this entry", http.StatusNotFound)
+		return
+	}
+	// Return the full entry including detail.
+	type detailResponse struct {
+		ID              int                 `json:"id"`
+		Method          string              `json:"method"`
+		Host            string              `json:"host"`
+		Path            string              `json:"path"`
+		Status          string              `json:"status"`
+		Detail          string              `json:"detail"`
+		RequestHeaders  map[string][]string `json:"request_headers"`
+		RequestBody     string              `json:"request_body"`
+		ResponseHeaders map[string][]string `json:"response_headers"`
+		ResponseBody    string              `json:"response_body"`
+		ResponseStatus  int                 `json:"response_status"`
+	}
+	writeJSON(w, http.StatusOK, detailResponse{
+		ID:              entry.ID,
+		Method:          entry.Method,
+		Host:            entry.Host,
+		Path:            entry.Path,
+		Status:          entry.Status,
+		Detail:          entry.Detail,
+		RequestHeaders:  entry.FullDetail.RequestHeaders,
+		RequestBody:     entry.FullDetail.RequestBody,
+		ResponseHeaders: entry.FullDetail.ResponseHeaders,
+		ResponseBody:    entry.FullDetail.ResponseBody,
+		ResponseStatus:  entry.FullDetail.ResponseStatus,
+	})
 }
 
 // --- Health ---

--- a/internal/approval/approval.go
+++ b/internal/approval/approval.go
@@ -26,16 +26,25 @@ const (
 //
 // PathPrefix optionally restricts the approval to URLs matching the prefix.
 // An empty PathPrefix means all paths are covered (backward compatible).
+// LoggingMode controls the level of request/response detail captured in logs.
+type LoggingMode string
+
+const (
+	LoggingModeNormal LoggingMode = "normal"
+	LoggingModeFull   LoggingMode = "full"
+)
+
 type HostApproval struct {
-	Host       string    `json:"host"`
-	SkillID    string    `json:"skill_id"`
-	SourceIP   string    `json:"source_ip"`
-	PathPrefix string    `json:"path_prefix,omitempty"`
-	Category   string    `json:"category,omitempty"`
-	Status     Status    `json:"status"`
-	CreatedAt  time.Time `json:"created_at"`
-	UpdatedAt  time.Time `json:"updated_at"`
-	Note       string    `json:"note"`
+	Host        string      `json:"host"`
+	SkillID     string      `json:"skill_id"`
+	SourceIP    string      `json:"source_ip"`
+	PathPrefix  string      `json:"path_prefix,omitempty"`
+	Category    string      `json:"category,omitempty"`
+	LoggingMode LoggingMode `json:"logging_mode,omitempty"`
+	Status      Status      `json:"status"`
+	CreatedAt   time.Time   `json:"created_at"`
+	UpdatedAt   time.Time   `json:"updated_at"`
+	Note        string      `json:"note"`
 }
 
 // key returns the unique key for a host+skill+sourceIP+pathPrefix combination.
@@ -410,6 +419,62 @@ func (m *Manager) CheckExistingWithMatcher(host, skillID, sourceIP string, match
 		}
 	}
 	return "", false
+}
+
+// GetLoggingMode returns the logging mode for the best matching approval.
+// It checks global, VM-specific, and skill-specific levels broadest-first,
+// using the same path-matching logic as CheckExistingWithPath.
+// Returns LoggingModeNormal if no matching approval is found or if the
+// matched approval has no explicit logging mode set.
+func (m *Manager) GetLoggingMode(host, path, skillID, sourceIP string) LoggingMode {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	// Check levels broadest-first: global -> VM -> skill.
+	levels := []struct{ sid, sip string }{
+		{"", ""},
+	}
+	if sourceIP != "" {
+		levels = append(levels, struct{ sid, sip string }{"", sourceIP})
+	}
+	if skillID != "" {
+		levels = append(levels, struct{ sid, sip string }{skillID, ""})
+	}
+
+	for _, lvl := range levels {
+		var bestMatch *HostApproval
+		bestLen := -1
+		for _, a := range m.approvals {
+			if a.SkillID != lvl.sid || a.SourceIP != lvl.sip {
+				continue
+			}
+			if !MatchHost(a.Host, host) {
+				continue
+			}
+			if !MatchPath(a.PathPrefix, path) {
+				continue
+			}
+			if len(a.PathPrefix) > bestLen {
+				bestMatch = a
+				bestLen = len(a.PathPrefix)
+			}
+		}
+		if bestMatch != nil && bestMatch.LoggingMode == LoggingModeFull {
+			return LoggingModeFull
+		}
+	}
+	return LoggingModeNormal
+}
+
+// SetLoggingMode updates the logging mode for an existing approval.
+func (m *Manager) SetLoggingMode(host, skillID, sourceIP, pathPrefix string, mode LoggingMode) {
+	k := key(host, skillID, sourceIP, pathPrefix)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if a, ok := m.approvals[k]; ok {
+		a.LoggingMode = mode
+		a.UpdatedAt = time.Now()
+	}
 }
 
 // SetCategory updates the category for an existing approval.

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -7,17 +7,29 @@ import (
 	"time"
 )
  
+// FullDetail stores the complete request and response data captured
+// when an approval rule has logging mode set to "full".
+type FullDetail struct {
+	RequestHeaders  map[string][]string `json:"request_headers,omitempty"`
+	RequestBody     string              `json:"request_body,omitempty"`
+	ResponseHeaders map[string][]string `json:"response_headers,omitempty"`
+	ResponseBody    string              `json:"response_body,omitempty"`
+	ResponseStatus  int                 `json:"response_status,omitempty"`
+}
+
 // Entry represents a single proxy log entry.
 type Entry struct {
-	ID        int       `json:"id"`
-	Timestamp time.Time `json:"timestamp"`
-	SkillID   string    `json:"skill_id"`
-	Method    string    `json:"method"`
-	Host      string    `json:"host"`
-	Path      string    `json:"path"`
-	Status    string    `json:"status"` // "allowed", "denied", "pending", "error"
-	Detail    string    `json:"detail"`
-	Duration  int64     `json:"duration_ms"`
+	ID          int         `json:"id"`
+	Timestamp   time.Time   `json:"timestamp"`
+	SkillID     string      `json:"skill_id"`
+	Method      string      `json:"method"`
+	Host        string      `json:"host"`
+	Path        string      `json:"path"`
+	Status      string      `json:"status"` // "allowed", "denied", "pending", "error"
+	Detail      string      `json:"detail"`
+	Duration    int64       `json:"duration_ms"`
+	HasFullLog  bool        `json:"has_full_log,omitempty"`
+	FullDetail  *FullDetail `json:"-"` // excluded from list responses, served via detail endpoint
 }
  
 // Logger stores log entries in memory with a configurable max size.
@@ -89,6 +101,18 @@ func (l *Logger) Since(afterID int) []Entry {
 	return result
 }
  
+// GetByID returns a single entry by ID including full detail data.
+func (l *Logger) GetByID(id int) (Entry, bool) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	for _, e := range l.entries {
+		if e.ID == id {
+			return e, true
+		}
+	}
+	return Entry{}, false
+}
+
 // Stats returns summary statistics.
 func (l *Logger) Stats() map[string]int {
 	l.mu.RLock()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4,6 +4,7 @@ package proxy
 
 import (
 	"bufio"
+	"bytes"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -25,6 +26,8 @@ const (
 	approvalTimeout = 5 * time.Minute
 	// AuthHeader is used by AI agents to provide their skill token.
 	AuthHeader = "X-Firewall4AI-Token"
+	// maxFullLogBody is the maximum body size captured in full logging mode.
+	maxFullLogBody = 64 * 1024 // 64 KB
 )
 
 // Proxy is the main proxy server.
@@ -230,6 +233,47 @@ func (p *Proxy) checkImageApproval(imageRef string, skill *auth.Skill, sourceIP 
 	return p.ImageApprovals.WaitForDecision(imageRef, sid, pendingIP, "", p.ApprovalTimeout)
 }
 
+// captureRequestBody reads the request body (up to maxFullLogBody) and replaces it
+// with a new reader so the request can still be forwarded.
+func captureRequestBody(r *http.Request) string {
+	if r.Body == nil {
+		return ""
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxFullLogBody+1))
+	r.Body.Close()
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	if err != nil {
+		return ""
+	}
+	if len(body) > maxFullLogBody {
+		return string(body[:maxFullLogBody]) + "... (truncated)"
+	}
+	return string(body)
+}
+
+// captureResponseBody reads the response body (up to maxFullLogBody).
+func captureResponseBody(resp *http.Response) string {
+	if resp.Body == nil {
+		return ""
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFullLogBody+1))
+	resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	if err != nil {
+		return ""
+	}
+	if len(body) > maxFullLogBody {
+		return string(body[:maxFullLogBody]) + "... (truncated)"
+	}
+	return string(body)
+}
+
+// getLoggingMode returns the logging mode for the request's host/path.
+func (p *Proxy) getLoggingMode(host, path string, skill *auth.Skill, sourceIP string) approval.LoggingMode {
+	sid := getSkillID(skill)
+	return p.Approvals.GetLoggingMode(host, path, sid, sourceIP)
+}
+
 func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	host := extractHost(r)
@@ -267,6 +311,17 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check logging mode before injecting credentials (capture pre-injection headers).
+	logMode := p.getLoggingMode(host, r.URL.Path, skill, sourceIP)
+	var fullDetail *proxylog.FullDetail
+	if logMode == approval.LoggingModeFull {
+		reqBody := captureRequestBody(r)
+		fullDetail = &proxylog.FullDetail{
+			RequestHeaders: r.Header.Clone(),
+			RequestBody:    reqBody,
+		}
+	}
+
 	// Inject credentials.
 	p.Credentials.InjectForRequest(r, sid)
 
@@ -282,27 +337,37 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	resp, err := p.Transport.RoundTrip(r)
 	if err != nil {
 		p.Logger.Add(proxylog.Entry{
-			SkillID:  sid,
-			Method:   r.Method,
-			Host:     host,
-			Path:     r.URL.Path,
-			Status:   "error",
-			Detail:   err.Error(),
-			Duration: time.Since(start).Milliseconds(),
+			SkillID:    sid,
+			Method:     r.Method,
+			Host:       host,
+			Path:       r.URL.Path,
+			Status:     "error",
+			Detail:     err.Error(),
+			Duration:   time.Since(start).Milliseconds(),
+			HasFullLog: fullDetail != nil,
+			FullDetail: fullDetail,
 		})
 		http.Error(w, "Proxy error: "+err.Error(), http.StatusBadGateway)
 		return
 	}
 	defer resp.Body.Close()
 
+	if fullDetail != nil {
+		fullDetail.ResponseHeaders = resp.Header.Clone()
+		fullDetail.ResponseStatus = resp.StatusCode
+		fullDetail.ResponseBody = captureResponseBody(resp)
+	}
+
 	p.Logger.Add(proxylog.Entry{
-		SkillID:  sid,
-		Method:   r.Method,
-		Host:     host,
-		Path:     r.URL.Path,
-		Status:   "allowed",
-		Detail:   fmt.Sprintf("%d %s", resp.StatusCode, resp.Status),
-		Duration: time.Since(start).Milliseconds(),
+		SkillID:    sid,
+		Method:     r.Method,
+		Host:       host,
+		Path:       r.URL.Path,
+		Status:     "allowed",
+		Detail:     fmt.Sprintf("%d %s", resp.StatusCode, resp.Status),
+		Duration:   time.Since(start).Milliseconds(),
+		HasFullLog: fullDetail != nil,
+		FullDetail: fullDetail,
 	})
 
 	// Copy response headers.
@@ -490,6 +555,17 @@ func (p *Proxy) handleMITMRequest(clientConn net.Conn, req *http.Request, host, 
 		return
 	}
 
+	// Check logging mode.
+	logMode := p.getLoggingMode(host, req.URL.Path, skill, sourceIP)
+	var fullDetail *proxylog.FullDetail
+	if logMode == approval.LoggingModeFull {
+		reqBody := captureRequestBody(req)
+		fullDetail = &proxylog.FullDetail{
+			RequestHeaders: req.Header.Clone(),
+			RequestBody:    reqBody,
+		}
+	}
+
 	// Set the URL for forwarding.
 	req.URL.Scheme = "https"
 	req.URL.Host = targetAddr
@@ -504,13 +580,15 @@ func (p *Proxy) handleMITMRequest(clientConn net.Conn, req *http.Request, host, 
 	resp, err := p.Transport.RoundTrip(req)
 	if err != nil {
 		p.Logger.Add(proxylog.Entry{
-			SkillID:  sid,
-			Method:   req.Method,
-			Host:     host,
-			Path:     req.URL.Path,
-			Status:   "error",
-			Detail:   err.Error(),
-			Duration: time.Since(start).Milliseconds(),
+			SkillID:    sid,
+			Method:     req.Method,
+			Host:       host,
+			Path:       req.URL.Path,
+			Status:     "error",
+			Detail:     err.Error(),
+			Duration:   time.Since(start).Milliseconds(),
+			HasFullLog: fullDetail != nil,
+			FullDetail: fullDetail,
 		})
 		// Send a 502 response to the client.
 		resp502 := &http.Response{
@@ -524,14 +602,22 @@ func (p *Proxy) handleMITMRequest(clientConn net.Conn, req *http.Request, host, 
 	}
 	defer resp.Body.Close()
 
+	if fullDetail != nil {
+		fullDetail.ResponseHeaders = resp.Header.Clone()
+		fullDetail.ResponseStatus = resp.StatusCode
+		fullDetail.ResponseBody = captureResponseBody(resp)
+	}
+
 	p.Logger.Add(proxylog.Entry{
-		SkillID:  sid,
-		Method:   req.Method,
-		Host:     host,
-		Path:     req.URL.Path,
-		Status:   "allowed",
-		Detail:   fmt.Sprintf("%d %s", resp.StatusCode, resp.Status),
-		Duration: time.Since(start).Milliseconds(),
+		SkillID:    sid,
+		Method:     req.Method,
+		Host:       host,
+		Path:       req.URL.Path,
+		Status:     "allowed",
+		Detail:     fmt.Sprintf("%d %s", resp.StatusCode, resp.Status),
+		Duration:   time.Since(start).Milliseconds(),
+		HasFullLog: fullDetail != nil,
+		FullDetail: fullDetail,
 	})
 
 	// Write response back to client.
@@ -695,6 +781,17 @@ func (p *Proxy) handleTransparentTLSRequest(clientConn net.Conn, req *http.Reque
 		return
 	}
 
+	// Check logging mode.
+	logMode := p.getLoggingMode(host, req.URL.Path, skill, sourceIP)
+	var fullDetail *proxylog.FullDetail
+	if logMode == approval.LoggingModeFull {
+		reqBody := captureRequestBody(req)
+		fullDetail = &proxylog.FullDetail{
+			RequestHeaders: req.Header.Clone(),
+			RequestBody:    reqBody,
+		}
+	}
+
 	// Set URL for forwarding to the real backend.
 	req.URL.Scheme = "https"
 	req.URL.Host = host + ":443"
@@ -706,13 +803,15 @@ func (p *Proxy) handleTransparentTLSRequest(clientConn net.Conn, req *http.Reque
 	resp, err := p.Transport.RoundTrip(req)
 	if err != nil {
 		p.Logger.Add(proxylog.Entry{
-			SkillID:  sid,
-			Method:   req.Method,
-			Host:     host,
-			Path:     req.URL.Path,
-			Status:   "error",
-			Detail:   err.Error(),
-			Duration: time.Since(start).Milliseconds(),
+			SkillID:    sid,
+			Method:     req.Method,
+			Host:       host,
+			Path:       req.URL.Path,
+			Status:     "error",
+			Detail:     err.Error(),
+			Duration:   time.Since(start).Milliseconds(),
+			HasFullLog: fullDetail != nil,
+			FullDetail: fullDetail,
 		})
 		resp502 := &http.Response{
 			StatusCode: http.StatusBadGateway,
@@ -725,14 +824,22 @@ func (p *Proxy) handleTransparentTLSRequest(clientConn net.Conn, req *http.Reque
 	}
 	defer resp.Body.Close()
 
+	if fullDetail != nil {
+		fullDetail.ResponseHeaders = resp.Header.Clone()
+		fullDetail.ResponseStatus = resp.StatusCode
+		fullDetail.ResponseBody = captureResponseBody(resp)
+	}
+
 	p.Logger.Add(proxylog.Entry{
-		SkillID:  sid,
-		Method:   req.Method,
-		Host:     host,
-		Path:     req.URL.Path,
-		Status:   "allowed",
-		Detail:   fmt.Sprintf("%d %s", resp.StatusCode, resp.Status),
-		Duration: time.Since(start).Milliseconds(),
+		SkillID:    sid,
+		Method:     req.Method,
+		Host:       host,
+		Path:       req.URL.Path,
+		Status:     "allowed",
+		Detail:     fmt.Sprintf("%d %s", resp.StatusCode, resp.Status),
+		Duration:   time.Since(start).Milliseconds(),
+		HasFullLog: fullDetail != nil,
+		FullDetail: fullDetail,
 	})
 
 	resp.Write(clientConn)

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -269,7 +269,7 @@ async function loadApprovals() {
     const tbody = document.getElementById('approvals-tbody');
     tbody.innerHTML = '';
     if (filtered.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="8" class="empty-state">No URL rules</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="9" class="empty-state">No URL rules</td></tr>';
       return;
     }
     filtered.sort((a, b) => a.host.localeCompare(b.host));
@@ -300,10 +300,14 @@ async function loadApprovals() {
            ${promoteBtn}
            ${editBtn} ${deleteBtn}`;
       }
+      const logModeDisplay = a.logging_mode === 'full'
+        ? '<span class="badge-status" style="background:rgba(99,102,241,0.15);color:var(--accent)">Full</span>'
+        : '<span class="badge-status" style="opacity:0.4">Normal</span>';
       tbody.innerHTML += `<tr>
         <td><strong>${esc(a.host)}</strong></td>
         <td>${pathDisplay}</td>
         <td>${categoryDisplay}</td>
+        <td>${logModeDisplay}</td>
         <td>${skillDisplay}</td>
         <td>${sourceDisplay}</td>
         <td><span class="badge-status ${a.status}">${a.status}</span></td>
@@ -369,6 +373,7 @@ function showAddRule() {
   document.getElementById('rule-skill-id').value = '';
   document.getElementById('rule-status').value = 'approved';
   populateCategorySelect('rule-category', '');
+  document.getElementById('rule-logging-mode').value = 'normal';
   document.getElementById('rule-note').value = '';
   updateRuleFields();
   document.getElementById('modal-rule').classList.add('active');
@@ -394,6 +399,7 @@ function showEditRule(idx) {
   }
   document.getElementById('rule-status').value = a.status === 'pending' ? 'approved' : a.status;
   populateCategorySelect('rule-category', a.category || '');
+  document.getElementById('rule-logging-mode').value = a.logging_mode || 'normal';
   document.getElementById('rule-note').value = a.note || '';
   updateRuleFields();
   document.getElementById('modal-rule').classList.add('active');
@@ -417,6 +423,7 @@ async function submitRule() {
   const level = document.getElementById('rule-level').value;
   const status = document.getElementById('rule-status').value;
   const category = document.getElementById('rule-category').value.trim();
+  const loggingMode = document.getElementById('rule-logging-mode').value;
   const note = document.getElementById('rule-note').value.trim();
   let sourceIP = '';
   let skillID = '';
@@ -444,7 +451,7 @@ async function submitRule() {
         });
       }
     }
-    await api('POST', '/api/approvals/decide', { host, skill_id: skillID, source_ip: sourceIP, path_prefix: pathPrefix, category, status, note });
+    await api('POST', '/api/approvals/decide', { host, skill_id: skillID, source_ip: sourceIP, path_prefix: pathPrefix, category, logging_mode: loggingMode, status, note });
     hideAddRule();
     loadApprovals();
   } catch (e) {
@@ -1011,10 +1018,13 @@ function renderLogs() {
   const tbody = document.getElementById('logs-tbody');
   tbody.innerHTML = '';
   if (filtered.length === 0) {
-    tbody.innerHTML = '<tr><td colspan="7" class="empty-state">No log entries yet</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="8" class="empty-state">No log entries yet</td></tr>';
     return;
   }
   filtered.forEach(l => {
+    const detailBtn = l.has_full_log
+      ? `<button class="btn btn-outline btn-sm" onclick="showLogDetail(${l.id})">Details</button>`
+      : '';
     tbody.innerHTML += `<tr>
       <td style="color:var(--text-dim);font-size:11px">${formatTime(l.timestamp)}</td>
       <td>${formatSkillID(l.skill_id)}</td>
@@ -1023,8 +1033,44 @@ function renderLogs() {
       <td>${esc(l.path || '-')}</td>
       <td><span class="badge-status ${l.status}">${l.status}</span></td>
       <td style="font-size:12px;color:var(--text-dim)">${esc(l.detail || '')}</td>
+      <td>${detailBtn}</td>
     </tr>`;
   });
+}
+
+// --- Log Detail ---
+async function showLogDetail(logId) {
+  try {
+    const detail = await api('GET', '/api/logs/detail?id=' + logId);
+    const content = document.getElementById('log-detail-content');
+    content.innerHTML = `
+      <div style="margin-bottom:12px">
+        <span class="method-badge">${esc(detail.method)}</span>
+        <strong>${esc(detail.host)}</strong>${esc(detail.path || '')}
+        <span class="badge-status ${detail.status}">${detail.status}</span>
+      </div>
+      <h4 style="margin:12px 0 6px;font-size:13px;color:var(--text-dim);text-transform:uppercase">Request Headers</h4>
+      <pre class="detail-pre">${formatHeaders(detail.request_headers)}</pre>
+      ${detail.request_body ? `<h4 style="margin:12px 0 6px;font-size:13px;color:var(--text-dim);text-transform:uppercase">Request Body</h4><pre class="detail-pre">${esc(detail.request_body)}</pre>` : ''}
+      <h4 style="margin:12px 0 6px;font-size:13px;color:var(--text-dim);text-transform:uppercase">Response ${detail.response_status ? detail.response_status : ''} Headers</h4>
+      <pre class="detail-pre">${formatHeaders(detail.response_headers)}</pre>
+      ${detail.response_body ? `<h4 style="margin:12px 0 6px;font-size:13px;color:var(--text-dim);text-transform:uppercase">Response Body</h4><pre class="detail-pre">${esc(detail.response_body)}</pre>` : ''}
+    `;
+    document.getElementById('modal-log-detail').classList.add('active');
+  } catch (e) {
+    alert('Error loading details: ' + e.message);
+  }
+}
+
+function hideLogDetail() {
+  document.getElementById('modal-log-detail').classList.remove('active');
+}
+
+function formatHeaders(headers) {
+  if (!headers || Object.keys(headers).length === 0) return '<span style="color:var(--text-dim)">(none)</span>';
+  return Object.entries(headers).map(([k, vals]) =>
+    vals.map(v => esc(k) + ': ' + esc(v)).join('\n')
+  ).join('\n');
 }
 
 // --- Polling ---

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -73,9 +73,9 @@
         </div>
         <div class="card">
           <table>
-            <thead><tr><th>Host</th><th>Path Prefix</th><th>Category</th><th>Skill</th><th>Source IP</th><th>Status</th><th>Updated</th><th>Actions</th></tr></thead>
+            <thead><tr><th>Host</th><th>Path Prefix</th><th>Category</th><th>Logging</th><th>Skill</th><th>Source IP</th><th>Status</th><th>Updated</th><th>Actions</th></tr></thead>
             <tbody id="approvals-tbody">
-              <tr><td colspan="8" class="empty-state">No URL rules</td></tr>
+              <tr><td colspan="9" class="empty-state">No URL rules</td></tr>
             </tbody>
           </table>
         </div>
@@ -172,9 +172,9 @@
         <div class="card">
           <div class="log-container">
             <table>
-              <thead><tr><th>Time</th><th>Skill</th><th>Method</th><th>Host</th><th>Path</th><th>Status</th><th>Detail</th></tr></thead>
+              <thead><tr><th>Time</th><th>Skill</th><th>Method</th><th>Host</th><th>Path</th><th>Status</th><th>Detail</th><th></th></tr></thead>
               <tbody id="logs-tbody">
-                <tr><td colspan="7" class="empty-state">No log entries yet</td></tr>
+                <tr><td colspan="8" class="empty-state">No log entries yet</td></tr>
             </tbody>
             </table>
           </div>
@@ -280,6 +280,13 @@
         <label>Category (optional)</label>
         <select id="rule-category">
           <option value="">No category</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label>Logging Mode</label>
+        <select id="rule-logging-mode">
+          <option value="normal">Normal</option>
+          <option value="full">Full (capture request/response headers and body)</option>
         </select>
       </div>
       <div class="form-group">
@@ -443,6 +450,17 @@
       <div class="modal-actions">
         <button class="btn btn-outline" onclick="hideImageRuleModal()">Cancel</button>
         <button class="btn btn-primary" id="modal-image-submit" onclick="submitImageRule()">Add Rule</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Log Detail Modal -->
+  <div id="modal-log-detail" class="modal-overlay">
+    <div class="modal" style="max-width:700px;max-height:80vh;overflow-y:auto">
+      <h3>Request Details</h3>
+      <div id="log-detail-content"></div>
+      <div class="modal-actions">
+        <button class="btn btn-outline" onclick="hideLogDetail()">Close</button>
       </div>
     </div>
   </div>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -305,6 +305,22 @@ tr:hover td { background: var(--surface2); }
 }
 .setting-control input:focus { border-color: var(--accent); }
 
+/* Log detail pre-formatted blocks */
+.detail-pre {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-family: monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 200px;
+  overflow-y: auto;
+  color: var(--text);
+  margin: 0;
+}
+
 /* Category badge */
 .category-badge {
   display: inline-block;


### PR DESCRIPTION
URL approval rules now have a "Logging Mode" field with two options:
- Normal (default): logs basic request metadata (method, host, path, status)
- Full: captures complete request/response headers and body (up to 64KB)

When Full mode is enabled for a URL rule, the proxy captures request headers and body before forwarding, and response headers and body after receiving the response. Log entries with full details show a "Details" button in the logs view that opens a modal with the complete request/response data.

Changes:
- approval: add LoggingMode field to HostApproval, GetLoggingMode() and SetLoggingMode() methods
- logging: add FullDetail struct, HasFullLog flag, GetByID() method
- proxy: capture full request/response data when matching rule has Full mode
- api: add logging_mode to decision requests, add GET /api/logs/detail endpoint
- admin UI: add Logging Mode dropdown to URL rule modal, Logging column in rules table, Details button in log rows, detail modal with headers/body view

https://claude.ai/code/session_01SxXj9qTTrbqFiTNLkLGX8w