### PR TITLE
Optimize rule performance with server-side filtering and pagination

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -45,6 +45,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/approvals/pending", h.listPending)
 	mux.HandleFunc("POST /api/approvals/decide", h.decideApproval)
 	mux.HandleFunc("PUT /api/approvals/category", h.setApprovalCategory)
+	mux.HandleFunc("GET /api/approvals/meta", h.approvalMeta)
 	mux.HandleFunc("DELETE /api/approvals", h.deleteApproval)
 
 	// Skills
@@ -64,6 +65,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/images/pending", h.listPendingImages)
 	mux.HandleFunc("POST /api/images/decide", h.decideImageApproval)
 	mux.HandleFunc("PUT /api/images/category", h.setImageCategory)
+	mux.HandleFunc("GET /api/images/meta", h.imageMeta)
 	mux.HandleFunc("DELETE /api/images", h.deleteImageApproval)
 
 	// OS Package Approvals (e.g., Debian)
@@ -71,6 +73,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/packages/pending", h.listPendingPackages)
 	mux.HandleFunc("POST /api/packages/decide", h.decidePackageApproval)
 	mux.HandleFunc("PUT /api/packages/category", h.setPackageCategory)
+	mux.HandleFunc("GET /api/packages/meta", h.packageMeta)
 	mux.HandleFunc("DELETE /api/packages", h.deletePackageApproval)
 
 	// Code Library Approvals (Go, npm, PyPI, NuGet)
@@ -78,7 +81,11 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/libraries/pending", h.listPendingLibraries)
 	mux.HandleFunc("POST /api/libraries/decide", h.decideLibraryApproval)
 	mux.HandleFunc("PUT /api/libraries/category", h.setLibraryCategory)
+	mux.HandleFunc("GET /api/libraries/meta", h.libraryMeta)
 	mux.HandleFunc("DELETE /api/libraries", h.deleteLibraryApproval)
+
+	// Pending counts (lightweight polling endpoint)
+	mux.HandleFunc("GET /api/pending-counts", h.getPendingCounts)
 
 	// Logs
 	mux.HandleFunc("GET /api/logs", h.getLogs)
@@ -122,12 +129,75 @@ func readJSON(r *http.Request, v any) error {
 
 // --- Approvals ---
 
+// parseFilterParams extracts common filter and pagination query parameters.
+func parseFilterParams(r *http.Request) approval.FilterParams {
+	p := approval.FilterParams{
+		Status:   r.URL.Query().Get("status"),
+		Category: r.URL.Query().Get("category"),
+		SkillID:  r.URL.Query().Get("skill_id"),
+		SourceIP: r.URL.Query().Get("source_ip"),
+		Type:     r.URL.Query().Get("type"),
+	}
+	if v := r.URL.Query().Get("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			p.Offset = n
+		}
+	}
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			p.Limit = n
+		}
+	}
+	return p
+}
+
 func (h *Handler) listApprovals(w http.ResponseWriter, r *http.Request) {
+	// If any filter/pagination params are present, use filtered endpoint.
+	if r.URL.Query().Has("limit") || r.URL.Query().Has("offset") ||
+		r.URL.Query().Has("status") || r.URL.Query().Has("category") ||
+		r.URL.Query().Has("skill_id") || r.URL.Query().Has("source_ip") {
+		p := parseFilterParams(r)
+		writeJSON(w, http.StatusOK, h.Approvals.ListFiltered(p))
+		return
+	}
 	writeJSON(w, http.StatusOK, h.Approvals.ListAll())
 }
 
 func (h *Handler) listPending(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, h.Approvals.ListPending())
+}
+
+func (h *Handler) approvalMeta(w http.ResponseWriter, r *http.Request) {
+	meta := h.Approvals.GetFilterMeta()
+	meta.Categories = h.ListCategoriesSlice()
+	writeJSON(w, http.StatusOK, meta)
+}
+
+func (h *Handler) imageMeta(w http.ResponseWriter, r *http.Request) {
+	meta := h.ImageApprovals.GetFilterMeta()
+	meta.Categories = h.ListCategoriesSlice()
+	writeJSON(w, http.StatusOK, meta)
+}
+
+func (h *Handler) packageMeta(w http.ResponseWriter, r *http.Request) {
+	meta := h.PackageApprovals.GetFilterMeta()
+	meta.Categories = h.ListCategoriesSlice()
+	writeJSON(w, http.StatusOK, meta)
+}
+
+func (h *Handler) libraryMeta(w http.ResponseWriter, r *http.Request) {
+	meta := h.LibraryApprovals.GetFilterMeta()
+	meta.Categories = h.ListCategoriesSlice()
+	writeJSON(w, http.StatusOK, meta)
+}
+
+func (h *Handler) getPendingCounts(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]int{
+		"approvals": h.Approvals.PendingCount(),
+		"images":    h.ImageApprovals.PendingCount(),
+		"packages":  h.PackageApprovals.PendingCount(),
+		"libraries": h.LibraryApprovals.PendingCount(),
+	})
 }
 
 type decisionRequest struct {
@@ -383,6 +453,13 @@ func (h *Handler) deleteCredential(w http.ResponseWriter, r *http.Request) {
 // --- Image Approvals ---
 
 func (h *Handler) listImageApprovals(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Has("limit") || r.URL.Query().Has("offset") ||
+		r.URL.Query().Has("status") || r.URL.Query().Has("category") ||
+		r.URL.Query().Has("skill_id") || r.URL.Query().Has("source_ip") {
+		p := parseFilterParams(r)
+		writeJSON(w, http.StatusOK, h.ImageApprovals.ListFiltered(p))
+		return
+	}
 	writeJSON(w, http.StatusOK, h.ImageApprovals.ListAll())
 }
 
@@ -426,6 +503,14 @@ func (h *Handler) deleteImageApproval(w http.ResponseWriter, r *http.Request) {
 // --- OS Package Approvals ---
 
 func (h *Handler) listPackageApprovals(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Has("limit") || r.URL.Query().Has("offset") ||
+		r.URL.Query().Has("status") || r.URL.Query().Has("category") ||
+		r.URL.Query().Has("skill_id") || r.URL.Query().Has("source_ip") ||
+		r.URL.Query().Has("type") {
+		p := parseFilterParams(r)
+		writeJSON(w, http.StatusOK, h.PackageApprovals.ListFiltered(p))
+		return
+	}
 	writeJSON(w, http.StatusOK, h.PackageApprovals.ListAll())
 }
 
@@ -480,6 +565,14 @@ func (h *Handler) deletePackageApproval(w http.ResponseWriter, r *http.Request) 
 // --- Code Library Approvals ---
 
 func (h *Handler) listLibraryApprovals(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Has("limit") || r.URL.Query().Has("offset") ||
+		r.URL.Query().Has("status") || r.URL.Query().Has("category") ||
+		r.URL.Query().Has("skill_id") || r.URL.Query().Has("source_ip") ||
+		r.URL.Query().Has("type") {
+		p := parseFilterParams(r)
+		writeJSON(w, http.StatusOK, h.LibraryApprovals.ListFiltered(p))
+		return
+	}
 	writeJSON(w, http.StatusOK, h.LibraryApprovals.ListAll())
 }
 

--- a/internal/approval/approval.go
+++ b/internal/approval/approval.go
@@ -4,6 +4,7 @@
 package approval
 
 import (
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -495,6 +496,145 @@ func (m *Manager) Delete(host, skillID, sourceIP, pathPrefix string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.approvals, k)
+}
+
+// FilterParams specifies optional filters and pagination for ListFiltered.
+type FilterParams struct {
+	Status   string // filter by status (empty = all)
+	Category string // filter by category (empty = all)
+	SkillID  string // filter by skill_id (empty = all; use "_empty" for no-skill)
+	SourceIP string // filter by source_ip (empty = all; use "_empty" for no-IP)
+	Type     string // filter by type prefix in host field, e.g. "golang" (empty = all)
+	Offset   int    // pagination offset
+	Limit    int    // pagination limit (0 = default 100)
+}
+
+// FilteredResult contains a page of approvals and the total matching count.
+type FilteredResult struct {
+	Items []HostApproval `json:"items"`
+	Total int            `json:"total"`
+}
+
+// ListFiltered returns approvals matching the given filters with pagination.
+func (m *Manager) ListFiltered(p FilterParams) FilteredResult {
+	if p.Limit <= 0 {
+		p.Limit = 100
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	// Collect matching items.
+	matched := make([]HostApproval, 0)
+	for _, a := range m.approvals {
+		if p.Status != "" && string(a.Status) != p.Status {
+			continue
+		}
+		if p.Category != "" && a.Category != p.Category {
+			continue
+		}
+		if p.SkillID == "_empty" {
+			if a.SkillID != "" {
+				continue
+			}
+		} else if p.SkillID != "" && a.SkillID != p.SkillID {
+			continue
+		}
+		if p.SourceIP == "_empty" {
+			if a.SourceIP != "" {
+				continue
+			}
+		} else if p.SourceIP != "" && a.SourceIP != p.SourceIP {
+			continue
+		}
+		if p.Type != "" {
+			idx := strings.Index(a.Host, ":")
+			if idx < 0 || a.Host[:idx] != p.Type {
+				continue
+			}
+		}
+		matched = append(matched, *a)
+	}
+
+	total := len(matched)
+
+	// Sort by host for stable pagination.
+	sort.Slice(matched, func(i, j int) bool {
+		return matched[i].Host < matched[j].Host
+	})
+
+	// Apply pagination.
+	if p.Offset >= len(matched) {
+		return FilteredResult{Items: []HostApproval{}, Total: total}
+	}
+	end := p.Offset + p.Limit
+	if end > len(matched) {
+		end = len(matched)
+	}
+	return FilteredResult{Items: matched[p.Offset:end], Total: total}
+}
+
+// PendingCount returns the number of pending approvals.
+func (m *Manager) PendingCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	count := 0
+	for _, a := range m.approvals {
+		if a.Status == StatusPending {
+			count++
+		}
+	}
+	return count
+}
+
+// FilterMeta returns the unique values for filter dropdowns.
+type FilterMeta struct {
+	Categories []string `json:"categories"`
+	SkillIDs   []string `json:"skill_ids"`
+	SourceIPs  []string `json:"source_ips"`
+	Types      []string `json:"types,omitempty"`
+}
+
+// GetFilterMeta returns unique filter values across all approvals.
+func (m *Manager) GetFilterMeta() FilterMeta {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	catSet := make(map[string]bool)
+	skillSet := make(map[string]bool)
+	ipSet := make(map[string]bool)
+	typeSet := make(map[string]bool)
+	for _, a := range m.approvals {
+		if a.Category != "" {
+			catSet[a.Category] = true
+		}
+		if a.SkillID != "" {
+			skillSet[a.SkillID] = true
+		}
+		if a.SourceIP != "" {
+			ipSet[a.SourceIP] = true
+		}
+		if idx := strings.Index(a.Host, ":"); idx > 0 {
+			typeSet[a.Host[:idx]] = true
+		}
+	}
+	meta := FilterMeta{
+		Categories: sortedKeys(catSet),
+		SkillIDs:   sortedKeys(skillSet),
+		SourceIPs:  sortedKeys(ipSet),
+		Types:      sortedKeys(typeSet),
+	}
+	return meta
+}
+
+func sortedKeys(m map[string]bool) []string {
+	if len(m) == 0 {
+		return []string{}
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // Export returns all approvals for persistence.

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -21,6 +21,15 @@ let currentCredentials = [];
 let currentCategories = [];
 let currentLogs = [];
 
+// Pagination state per page type
+const PAGE_SIZE = 50;
+let pageState = {
+  url: { offset: 0, total: 0 },
+  image: { offset: 0, total: 0 },
+  package: { offset: 0, total: 0 },
+  library: { offset: 0, total: 0 },
+};
+
 // Selection state for bulk actions
 let selectedApprovals = new Set();
 let selectedImages = new Set();
@@ -297,10 +306,63 @@ function clearFilters(prefix) {
   if (skill) skill.value = '';
   if (ip) ip.value = '';
   if (status) status.value = '';
+  pageState[prefix].offset = 0;
   if (prefix === 'url') loadApprovals();
   if (prefix === 'image') loadImages();
   if (prefix === 'package') loadPackages();
   if (prefix === 'library') loadLibraries();
+}
+
+// Build query string for server-side filtered + paginated requests.
+function buildFilterQuery(prefix) {
+  const filter = prefix === 'package' || prefix === 'library' ? getTypedFilter(prefix) : getFilter(prefix);
+  const ps = pageState[prefix];
+  const params = new URLSearchParams();
+  if (filter.status) params.set('status', filter.status);
+  if (filter.category) params.set('category', filter.category);
+  if (filter.skillID) params.set('skill_id', filter.skillID);
+  if (filter.ip) params.set('source_ip', filter.ip);
+  if (filter.type) params.set('type', filter.type);
+  params.set('offset', ps.offset);
+  params.set('limit', PAGE_SIZE);
+  return params.toString();
+}
+
+// Render pagination controls.
+function renderPager(prefix) {
+  const pager = document.getElementById('pager-' + prefix);
+  if (!pager) return;
+  const ps = pageState[prefix];
+  if (ps.total <= PAGE_SIZE) {
+    pager.style.display = 'none';
+    return;
+  }
+  pager.style.display = 'flex';
+  const page = Math.floor(ps.offset / PAGE_SIZE) + 1;
+  const totalPages = Math.ceil(ps.total / PAGE_SIZE);
+  const prevDisabled = ps.offset === 0 ? 'disabled' : '';
+  const nextDisabled = ps.offset + PAGE_SIZE >= ps.total ? 'disabled' : '';
+  pager.innerHTML = `<span>Showing ${ps.offset + 1}-${Math.min(ps.offset + PAGE_SIZE, ps.total)} of ${ps.total}</span>
+    <div class="pager-buttons">
+      <button ${prevDisabled} onclick="goPage('${prefix}',-1)">Previous</button>
+      <span style="padding:4px 8px">Page ${page} of ${totalPages}</span>
+      <button ${nextDisabled} onclick="goPage('${prefix}',1)">Next</button>
+    </div>`;
+}
+
+function goPage(prefix, dir) {
+  const ps = pageState[prefix];
+  ps.offset += dir * PAGE_SIZE;
+  if (ps.offset < 0) ps.offset = 0;
+  const loaders = { url: loadApprovals, image: loadImages, package: loadPackages, library: loadLibraries };
+  loaders[prefix]();
+}
+
+// Reset page offset when filter changes.
+function onFilterChange(prefix) {
+  pageState[prefix].offset = 0;
+  const loaders = { url: loadApprovals, image: loadImages, package: loadPackages, library: loadLibraries };
+  loaders[prefix]();
 }
 
 // --- Selection & Bulk Actions ---
@@ -509,78 +571,77 @@ async function refreshSkills() {
 // --- URL Rules (Approvals) ---
 async function loadApprovals() {
   try {
-    const [approvals] = await Promise.all([
-      api('GET', '/api/approvals'),
-      refreshCategories(),
+    const query = buildFilterQuery('url');
+    const [result, meta] = await Promise.all([
+      api('GET', '/api/approvals?' + query),
+      api('GET', '/api/approvals/meta'),
       refreshSkills(),
     ]);
-    currentApprovals = approvals || [];
-    populateFilterDropdowns('url', currentApprovals);
-    const pending = currentApprovals.filter(a => a.status === 'pending');
-    const badge = document.getElementById('approval-badge');
-    if (pending.length > 0) {
-      badge.textContent = pending.length;
-      badge.style.display = 'inline';
-    } else {
-      badge.style.display = 'none';
-    }
-    const filter = getFilter('url');
-    const filtered = currentApprovals.filter(a => matchesFilter(a, filter));
+    const items = result.items || [];
+    const total = result.total || 0;
+    pageState.url.total = total;
+    currentApprovals = items;
+    currentFilteredApprovals = items;
+    // Populate filter dropdowns from meta (not from full data).
+    currentCategories = meta.categories || [];
+    populateSelect('filter-url-category', currentCategories.map(c => ({ value: c, label: c })), 'All categories');
+    const skillOpts = (meta.skill_ids || []).map(id => ({ value: id, label: skillNameByID(id) }));
+    skillOpts.sort((a, b) => a.label.localeCompare(b.label));
+    populateSelect('filter-url-skill', skillOpts, 'All skills');
+    populateSelect('filter-url-ip', (meta.source_ips || []).map(ip => ({ value: ip, label: ip })), 'All source IPs');
     const tbody = document.getElementById('approvals-tbody');
-    tbody.innerHTML = '';
-    currentFilteredApprovals = filtered;
-    if (filtered.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="10" class="empty-state">No URL rules</td></tr>';
-      updateBulkBar('url');
-      return;
+    const rows = [];
+    if (items.length === 0) {
+      rows.push('<tr><td colspan="10" class="empty-state">No URL rules</td></tr>');
+    } else {
+      items.forEach((a, i) => {
+        const key = approvalKey(a);
+        const cbChecked = selectedApprovals.has(key) ? 'checked' : '';
+        const skillDisplay = formatSkillID(a.skill_id);
+        const sourceDisplay = formatSourceIP(a.source_ip);
+        const pathDisplay = formatPathPrefix(a.path_prefix);
+        const categoryDisplay = formatCategory(a.category);
+        const pp = a.path_prefix || '';
+        const editBtn = `<button class="btn btn-outline btn-sm" onclick="showEditRule(${i})" title="Edit rule">Edit</button>`;
+        const deleteBtn = `<button class="btn btn-danger btn-sm" onclick="deleteApproval('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','${esc(pp)}')" title="Delete rule">Delete</button>`;
+        let actions = '';
+        if (a.status === 'pending') {
+          const vmBtn = a.source_ip
+            ? `<button class="btn btn-outline btn-sm" onclick="decide('${esc(a.host)}','','${esc(a.source_ip)}','${esc(pp)}','approved')" title="Approve for this VM">VM</button>` : '';
+          const globalBtn = (a.skill_id || a.source_ip)
+            ? `<button class="btn btn-outline btn-sm" onclick="decide('${esc(a.host)}','','','${esc(pp)}','approved')" title="Approve for all agents">Global</button>` : '';
+          actions = `<button class="btn btn-success btn-sm" onclick="decide('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','${esc(pp)}','approved')">Approve</button>
+             ${vmBtn} ${globalBtn}
+             <button class="btn btn-danger btn-sm" onclick="decide('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','${esc(pp)}','denied')">Deny</button>
+             ${editBtn} ${deleteBtn}`;
+        } else {
+          const promoteBtn = a.source_ip && !a.skill_id
+            ? `<button class="btn btn-outline btn-sm" onclick="promoteToGlobal('${esc(a.host)}','${esc(a.source_ip)}','${esc(pp)}','${a.status}')" title="Promote to global rule">Promote to Global</button>` : '';
+          actions = `<button class="btn btn-outline btn-sm" onclick="decide('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','${esc(pp)}','approved')">Approve</button>
+             <button class="btn btn-outline btn-sm" onclick="decide('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','${esc(pp)}','denied')">Deny</button>
+             ${promoteBtn}
+             ${editBtn} ${deleteBtn}`;
+        }
+        const logModeDisplay = a.logging_mode === 'full'
+          ? '<span class="badge-status" style="background:rgba(99,102,241,0.15);color:var(--accent)">Full</span>'
+          : '<span class="badge-status" style="opacity:0.4">Normal</span>';
+        rows.push(`<tr>
+          <td class="cb-col"><input type="checkbox" class="row-cb" data-key="${esc(key)}" ${cbChecked} onchange="toggleSelect('url',this)"></td>
+          <td><strong>${esc(a.host)}</strong></td>
+          <td>${pathDisplay}</td>
+          <td>${categoryDisplay}</td>
+          <td>${logModeDisplay}</td>
+          <td>${skillDisplay}</td>
+          <td>${sourceDisplay}</td>
+          <td><span class="badge-status ${a.status}">${a.status}</span></td>
+          <td>${timeAgo(a.updated_at)}</td>
+          <td>${actions}</td>
+        </tr>`);
+      });
     }
-    filtered.sort((a, b) => a.host.localeCompare(b.host));
-    filtered.forEach((a) => {
-      const key = approvalKey(a);
-      const cbChecked = selectedApprovals.has(key) ? 'checked' : '';
-      const idx = currentApprovals.indexOf(a);
-      const skillDisplay = formatSkillID(a.skill_id);
-      const sourceDisplay = formatSourceIP(a.source_ip);
-      const pathDisplay = formatPathPrefix(a.path_prefix);
-      const categoryDisplay = formatCategory(a.category);
-      const pp = a.path_prefix || '';
-      const editBtn = `<button class="btn btn-outline btn-sm" onclick="showEditRule(${idx})" title="Edit rule">Edit</button>`;
-      const deleteBtn = `<button class="btn btn-danger btn-sm" onclick="deleteApproval('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','${esc(pp)}')" title="Delete rule">Delete</button>`;
-      let actions = '';
-      if (a.status === 'pending') {
-        const vmBtn = a.source_ip
-          ? `<button class="btn btn-outline btn-sm" onclick="decide('${esc(a.host)}','','${esc(a.source_ip)}','${esc(pp)}','approved')" title="Approve for this VM">VM</button>` : '';
-        const globalBtn = (a.skill_id || a.source_ip)
-          ? `<button class="btn btn-outline btn-sm" onclick="decide('${esc(a.host)}','','','${esc(pp)}','approved')" title="Approve for all agents">Global</button>` : '';
-        actions = `<button class="btn btn-success btn-sm" onclick="decide('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','${esc(pp)}','approved')">Approve</button>
-           ${vmBtn} ${globalBtn}
-           <button class="btn btn-danger btn-sm" onclick="decide('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','${esc(pp)}','denied')">Deny</button>
-           ${editBtn} ${deleteBtn}`;
-      } else {
-        const promoteBtn = a.source_ip && !a.skill_id
-          ? `<button class="btn btn-outline btn-sm" onclick="promoteToGlobal('${esc(a.host)}','${esc(a.source_ip)}','${esc(pp)}','${a.status}')" title="Promote to global rule">Promote to Global</button>` : '';
-        actions = `<button class="btn btn-outline btn-sm" onclick="decide('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','${esc(pp)}','approved')">Approve</button>
-           <button class="btn btn-outline btn-sm" onclick="decide('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','${esc(pp)}','denied')">Deny</button>
-           ${promoteBtn}
-           ${editBtn} ${deleteBtn}`;
-      }
-      const logModeDisplay = a.logging_mode === 'full'
-        ? '<span class="badge-status" style="background:rgba(99,102,241,0.15);color:var(--accent)">Full</span>'
-        : '<span class="badge-status" style="opacity:0.4">Normal</span>';
-      tbody.innerHTML += `<tr>
-        <td class="cb-col"><input type="checkbox" class="row-cb" data-key="${esc(key)}" ${cbChecked} onchange="toggleSelect('url',this)"></td>
-        <td><strong>${esc(a.host)}</strong></td>
-        <td>${pathDisplay}</td>
-        <td>${categoryDisplay}</td>
-        <td>${logModeDisplay}</td>
-        <td>${skillDisplay}</td>
-        <td>${sourceDisplay}</td>
-        <td><span class="badge-status ${a.status}">${a.status}</span></td>
-        <td>${timeAgo(a.updated_at)}</td>
-        <td>${actions}</td>
-      </tr>`;
-    });
+    tbody.innerHTML = rows.join('');
     updateBulkBar('url');
+    renderPager('url');
   } catch (e) {
     console.error('URL rules load error:', e);
   }
@@ -729,71 +790,68 @@ async function submitRule() {
 // --- Images ---
 async function loadImages() {
   try {
-    const [images] = await Promise.all([
-      api('GET', '/api/images'),
-      refreshCategories(),
+    const query = buildFilterQuery('image');
+    const [result, meta] = await Promise.all([
+      api('GET', '/api/images?' + query),
+      api('GET', '/api/images/meta'),
       refreshSkills(),
     ]);
-    currentImages = images || [];
-    populateFilterDropdowns('image', currentImages);
-    const pending = currentImages.filter(a => a.status === 'pending');
-    const badge = document.getElementById('image-badge');
-    if (pending.length > 0) {
-      badge.textContent = pending.length;
-      badge.style.display = 'inline';
-    } else {
-      badge.style.display = 'none';
-    }
-    const filter = getFilter('image');
-    const filtered = currentImages.filter(a => matchesFilter(a, filter));
+    const items = result.items || [];
+    pageState.image.total = result.total || 0;
+    currentImages = items;
+    currentFilteredImages = items;
+    currentCategories = meta.categories || [];
+    populateSelect('filter-image-category', currentCategories.map(c => ({ value: c, label: c })), 'All categories');
+    const skillOpts = (meta.skill_ids || []).map(id => ({ value: id, label: skillNameByID(id) }));
+    skillOpts.sort((a, b) => a.label.localeCompare(b.label));
+    populateSelect('filter-image-skill', skillOpts, 'All skills');
+    populateSelect('filter-image-ip', (meta.source_ips || []).map(ip => ({ value: ip, label: ip })), 'All source IPs');
     const tbody = document.getElementById('images-tbody');
-    tbody.innerHTML = '';
-    currentFilteredImages = filtered;
-    if (filtered.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="8" class="empty-state">No image approval records</td></tr>';
-      updateBulkBar('image');
-      return;
+    const rows = [];
+    if (items.length === 0) {
+      rows.push('<tr><td colspan="8" class="empty-state">No image approval records</td></tr>');
+    } else {
+      items.forEach((a, i) => {
+        const key = imgKey(a);
+        const cbChecked = selectedImages.has(key) ? 'checked' : '';
+        const skillDisplay = formatSkillID(a.skill_id);
+        const sourceDisplay = formatSourceIP(a.source_ip);
+        const categoryDisplay = formatCategory(a.category);
+        const editBtn = `<button class="btn btn-outline btn-sm" onclick="showEditImageRule(${i})" title="Edit rule">Edit</button>`;
+        const deleteBtn = `<button class="btn btn-danger btn-sm" onclick="deleteImage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}')" title="Delete rule">Delete</button>`;
+        let actions = '';
+        if (a.status === 'pending') {
+          const vmBtn = a.source_ip
+            ? `<button class="btn btn-outline btn-sm" onclick="decideImage('${esc(a.host)}','','${esc(a.source_ip)}','approved')" title="Approve for this VM">VM</button>` : '';
+          const globalBtn = (a.skill_id || a.source_ip)
+            ? `<button class="btn btn-outline btn-sm" onclick="decideImage('${esc(a.host)}','','','approved')" title="Approve for all agents">Global</button>` : '';
+          actions = `<button class="btn btn-success btn-sm" onclick="decideImage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','approved')">Approve</button>
+             ${vmBtn} ${globalBtn}
+             <button class="btn btn-danger btn-sm" onclick="decideImage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','denied')">Deny</button>
+             ${editBtn} ${deleteBtn}`;
+        } else {
+          const promoteBtn = a.source_ip && !a.skill_id
+            ? `<button class="btn btn-outline btn-sm" onclick="promoteImageToGlobal('${esc(a.host)}','${esc(a.source_ip)}','${a.status}')" title="Promote to global rule">Promote to Global</button>` : '';
+          actions = `<button class="btn btn-outline btn-sm" onclick="decideImage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','approved')">Approve</button>
+             <button class="btn btn-outline btn-sm" onclick="decideImage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','denied')">Deny</button>
+             ${promoteBtn}
+             ${editBtn} ${deleteBtn}`;
+        }
+        rows.push(`<tr>
+          <td class="cb-col"><input type="checkbox" class="row-cb" data-key="${esc(key)}" ${cbChecked} onchange="toggleSelect('image',this)"></td>
+          <td><strong>${esc(a.host)}</strong></td>
+          <td>${categoryDisplay}</td>
+          <td>${skillDisplay}</td>
+          <td>${sourceDisplay}</td>
+          <td><span class="badge-status ${a.status}">${a.status}</span></td>
+          <td>${timeAgo(a.updated_at)}</td>
+          <td>${actions}</td>
+        </tr>`);
+      });
     }
-    filtered.sort((a, b) => a.host.localeCompare(b.host));
-    filtered.forEach((a) => {
-      const key = imgKey(a);
-      const cbChecked = selectedImages.has(key) ? 'checked' : '';
-      const idx = currentImages.indexOf(a);
-      const skillDisplay = formatSkillID(a.skill_id);
-      const sourceDisplay = formatSourceIP(a.source_ip);
-      const categoryDisplay = formatCategory(a.category);
-      const editBtn = `<button class="btn btn-outline btn-sm" onclick="showEditImageRule(${idx})" title="Edit rule">Edit</button>`;
-      const deleteBtn = `<button class="btn btn-danger btn-sm" onclick="deleteImage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}')" title="Delete rule">Delete</button>`;
-      let actions = '';
-      if (a.status === 'pending') {
-        const vmBtn = a.source_ip
-          ? `<button class="btn btn-outline btn-sm" onclick="decideImage('${esc(a.host)}','','${esc(a.source_ip)}','approved')" title="Approve for this VM">VM</button>` : '';
-        const globalBtn = (a.skill_id || a.source_ip)
-          ? `<button class="btn btn-outline btn-sm" onclick="decideImage('${esc(a.host)}','','','approved')" title="Approve for all agents">Global</button>` : '';
-        actions = `<button class="btn btn-success btn-sm" onclick="decideImage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','approved')">Approve</button>
-           ${vmBtn} ${globalBtn}
-           <button class="btn btn-danger btn-sm" onclick="decideImage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','denied')">Deny</button>
-           ${editBtn} ${deleteBtn}`;
-      } else {
-        const promoteBtn = a.source_ip && !a.skill_id
-          ? `<button class="btn btn-outline btn-sm" onclick="promoteImageToGlobal('${esc(a.host)}','${esc(a.source_ip)}','${a.status}')" title="Promote to global rule">Promote to Global</button>` : '';
-        actions = `<button class="btn btn-outline btn-sm" onclick="decideImage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','approved')">Approve</button>
-           <button class="btn btn-outline btn-sm" onclick="decideImage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','denied')">Deny</button>
-           ${promoteBtn}
-           ${editBtn} ${deleteBtn}`;
-      }
-      tbody.innerHTML += `<tr>
-        <td class="cb-col"><input type="checkbox" class="row-cb" data-key="${esc(key)}" ${cbChecked} onchange="toggleSelect('image',this)"></td>
-        <td><strong>${esc(a.host)}</strong></td>
-        <td>${categoryDisplay}</td>
-        <td>${skillDisplay}</td>
-        <td>${sourceDisplay}</td>
-        <td><span class="badge-status ${a.status}">${a.status}</span></td>
-        <td>${timeAgo(a.updated_at)}</td>
-        <td>${actions}</td>
-      </tr>`;
-    });
+    tbody.innerHTML = rows.join('');
     updateBulkBar('image');
+    renderPager('image');
   } catch (e) {
     console.error('Images load error:', e);
   }
@@ -920,69 +978,73 @@ async function submitImageRule() {
 // --- OS Packages ---
 async function loadPackages() {
   try {
-    const [packages] = await Promise.all([
-      api('GET', '/api/packages'),
-      refreshCategories(),
+    const query = buildFilterQuery('package');
+    const [result, meta] = await Promise.all([
+      api('GET', '/api/packages?' + query),
+      api('GET', '/api/packages/meta'),
       refreshSkills(),
     ]);
-    currentPackages = packages || [];
-    populateFilterDropdowns('package', currentPackages);
-    populateTypeFilter('package', currentPackages);
-    const pending = currentPackages.filter(a => a.status === 'pending');
-    updateBadge('package-badge', pending);
-    const filter = getTypedFilter('package');
-    const filtered = currentPackages.filter(a => matchesFilter(a, filter));
+    const items = result.items || [];
+    pageState.package.total = result.total || 0;
+    currentPackages = items;
+    currentFilteredPackages = items;
+    currentCategories = meta.categories || [];
+    populateSelect('filter-package-category', currentCategories.map(c => ({ value: c, label: c })), 'All categories');
+    const skillOpts = (meta.skill_ids || []).map(id => ({ value: id, label: skillNameByID(id) }));
+    skillOpts.sort((a, b) => a.label.localeCompare(b.label));
+    populateSelect('filter-package-skill', skillOpts, 'All skills');
+    populateSelect('filter-package-ip', (meta.source_ips || []).map(ip => ({ value: ip, label: ip })), 'All source IPs');
+    const typeOpts = (meta.types || []).map(t => ({ value: t, label: typeLabels[t] || t }));
+    populateSelect('filter-package-type', typeOpts, 'All types');
     const tbody = document.getElementById('packages-tbody');
-    tbody.innerHTML = '';
-    currentFilteredPackages = filtered;
-    if (filtered.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="9" class="empty-state">No OS package approval records</td></tr>';
-      updateBulkBar('package');
-      return;
+    const rows = [];
+    if (items.length === 0) {
+      rows.push('<tr><td colspan="9" class="empty-state">No OS package approval records</td></tr>');
+    } else {
+      items.forEach((a, i) => {
+        const key = imgKey(a);
+        const cbChecked = selectedPackages.has(key) ? 'checked' : '';
+        const skillDisplay = formatSkillID(a.skill_id);
+        const sourceDisplay = formatSourceIP(a.source_ip);
+        const categoryDisplay = formatCategory(a.category);
+        const typeDisplay = formatLibraryType(a.host);
+        const nameDisplay = formatLibraryName(a.host);
+        const editBtn = `<button class="btn btn-outline btn-sm" onclick="showEditPackageRule(${i})" title="Edit rule">Edit</button>`;
+        const deleteBtn = `<button class="btn btn-danger btn-sm" onclick="deletePackage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}')" title="Delete rule">Delete</button>`;
+        let actions = '';
+        if (a.status === 'pending') {
+          const vmBtn = a.source_ip
+            ? `<button class="btn btn-outline btn-sm" onclick="decidePackage('${esc(a.host)}','','${esc(a.source_ip)}','approved')" title="Approve for this VM">VM</button>` : '';
+          const globalBtn = (a.skill_id || a.source_ip)
+            ? `<button class="btn btn-outline btn-sm" onclick="decidePackage('${esc(a.host)}','','','approved')" title="Approve for all agents">Global</button>` : '';
+          actions = `<button class="btn btn-success btn-sm" onclick="decidePackage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','approved')">Approve</button>
+             ${vmBtn} ${globalBtn}
+             <button class="btn btn-danger btn-sm" onclick="decidePackage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','denied')">Deny</button>
+             ${editBtn} ${deleteBtn}`;
+        } else {
+          const promoteBtn = a.source_ip && !a.skill_id
+            ? `<button class="btn btn-outline btn-sm" onclick="promotePackageToGlobal('${esc(a.host)}','${esc(a.source_ip)}','${a.status}')" title="Promote to global rule">Promote to Global</button>` : '';
+          actions = `<button class="btn btn-outline btn-sm" onclick="decidePackage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','approved')">Approve</button>
+             <button class="btn btn-outline btn-sm" onclick="decidePackage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','denied')">Deny</button>
+             ${promoteBtn}
+             ${editBtn} ${deleteBtn}`;
+        }
+        rows.push(`<tr>
+          <td class="cb-col"><input type="checkbox" class="row-cb" data-key="${esc(key)}" ${cbChecked} onchange="toggleSelect('package',this)"></td>
+          <td><strong>${nameDisplay}</strong></td>
+          <td>${typeDisplay}</td>
+          <td>${categoryDisplay}</td>
+          <td>${skillDisplay}</td>
+          <td>${sourceDisplay}</td>
+          <td><span class="badge-status ${a.status}">${a.status}</span></td>
+          <td>${timeAgo(a.updated_at)}</td>
+          <td>${actions}</td>
+        </tr>`);
+      });
     }
-    filtered.sort((a, b) => getLibraryName(a.host).localeCompare(getLibraryName(b.host)));
-    filtered.forEach((a) => {
-      const key = imgKey(a);
-      const cbChecked = selectedPackages.has(key) ? 'checked' : '';
-      const idx = currentPackages.indexOf(a);
-      const skillDisplay = formatSkillID(a.skill_id);
-      const sourceDisplay = formatSourceIP(a.source_ip);
-      const categoryDisplay = formatCategory(a.category);
-      const typeDisplay = formatLibraryType(a.host);
-      const nameDisplay = formatLibraryName(a.host);
-      const editBtn = `<button class="btn btn-outline btn-sm" onclick="showEditPackageRule(${idx})" title="Edit rule">Edit</button>`;
-      const deleteBtn = `<button class="btn btn-danger btn-sm" onclick="deletePackage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}')" title="Delete rule">Delete</button>`;
-      let actions = '';
-      if (a.status === 'pending') {
-        const vmBtn = a.source_ip
-          ? `<button class="btn btn-outline btn-sm" onclick="decidePackage('${esc(a.host)}','','${esc(a.source_ip)}','approved')" title="Approve for this VM">VM</button>` : '';
-        const globalBtn = (a.skill_id || a.source_ip)
-          ? `<button class="btn btn-outline btn-sm" onclick="decidePackage('${esc(a.host)}','','','approved')" title="Approve for all agents">Global</button>` : '';
-        actions = `<button class="btn btn-success btn-sm" onclick="decidePackage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','approved')">Approve</button>
-           ${vmBtn} ${globalBtn}
-           <button class="btn btn-danger btn-sm" onclick="decidePackage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','denied')">Deny</button>
-           ${editBtn} ${deleteBtn}`;
-      } else {
-        const promoteBtn = a.source_ip && !a.skill_id
-          ? `<button class="btn btn-outline btn-sm" onclick="promotePackageToGlobal('${esc(a.host)}','${esc(a.source_ip)}','${a.status}')" title="Promote to global rule">Promote to Global</button>` : '';
-        actions = `<button class="btn btn-outline btn-sm" onclick="decidePackage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','approved')">Approve</button>
-           <button class="btn btn-outline btn-sm" onclick="decidePackage('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','denied')">Deny</button>
-           ${promoteBtn}
-           ${editBtn} ${deleteBtn}`;
-      }
-      tbody.innerHTML += `<tr>
-        <td class="cb-col"><input type="checkbox" class="row-cb" data-key="${esc(key)}" ${cbChecked} onchange="toggleSelect('package',this)"></td>
-        <td><strong>${nameDisplay}</strong></td>
-        <td>${typeDisplay}</td>
-        <td>${categoryDisplay}</td>
-        <td>${skillDisplay}</td>
-        <td>${sourceDisplay}</td>
-        <td><span class="badge-status ${a.status}">${a.status}</span></td>
-        <td>${timeAgo(a.updated_at)}</td>
-        <td>${actions}</td>
-      </tr>`;
-    });
+    tbody.innerHTML = rows.join('');
     updateBulkBar('package');
+    renderPager('package');
   } catch (e) {
     console.error('Packages load error:', e);
   }
@@ -1095,69 +1157,73 @@ async function submitPackageRule() {
 // --- Code Libraries ---
 async function loadLibraries() {
   try {
-    const [libraries] = await Promise.all([
-      api('GET', '/api/libraries'),
-      refreshCategories(),
+    const query = buildFilterQuery('library');
+    const [result, meta] = await Promise.all([
+      api('GET', '/api/libraries?' + query),
+      api('GET', '/api/libraries/meta'),
       refreshSkills(),
     ]);
-    currentLibraries = libraries || [];
-    populateFilterDropdowns('library', currentLibraries);
-    populateTypeFilter('library', currentLibraries);
-    const pending = currentLibraries.filter(a => a.status === 'pending');
-    updateBadge('library-badge', pending);
-    const filter = getTypedFilter('library');
-    const filtered = currentLibraries.filter(a => matchesFilter(a, filter));
+    const items = result.items || [];
+    pageState.library.total = result.total || 0;
+    currentLibraries = items;
+    currentFilteredLibraries = items;
+    currentCategories = meta.categories || [];
+    populateSelect('filter-library-category', currentCategories.map(c => ({ value: c, label: c })), 'All categories');
+    const skillOpts = (meta.skill_ids || []).map(id => ({ value: id, label: skillNameByID(id) }));
+    skillOpts.sort((a, b) => a.label.localeCompare(b.label));
+    populateSelect('filter-library-skill', skillOpts, 'All skills');
+    populateSelect('filter-library-ip', (meta.source_ips || []).map(ip => ({ value: ip, label: ip })), 'All source IPs');
+    const typeOpts = (meta.types || []).map(t => ({ value: t, label: typeLabels[t] || t }));
+    populateSelect('filter-library-type', typeOpts, 'All types');
     const tbody = document.getElementById('libraries-tbody');
-    tbody.innerHTML = '';
-    currentFilteredLibraries = filtered;
-    if (filtered.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="9" class="empty-state">No code library approval records</td></tr>';
-      updateBulkBar('library');
-      return;
+    const rows = [];
+    if (items.length === 0) {
+      rows.push('<tr><td colspan="9" class="empty-state">No code library approval records</td></tr>');
+    } else {
+      items.forEach((a, i) => {
+        const key = imgKey(a);
+        const cbChecked = selectedLibraries.has(key) ? 'checked' : '';
+        const skillDisplay = formatSkillID(a.skill_id);
+        const sourceDisplay = formatSourceIP(a.source_ip);
+        const categoryDisplay = formatCategory(a.category);
+        const typeDisplay = formatLibraryType(a.host);
+        const nameDisplay = formatLibraryName(a.host);
+        const editBtn = `<button class="btn btn-outline btn-sm" onclick="showEditLibraryRule(${i})" title="Edit rule">Edit</button>`;
+        const deleteBtn = `<button class="btn btn-danger btn-sm" onclick="deleteLibrary('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}')" title="Delete rule">Delete</button>`;
+        let actions = '';
+        if (a.status === 'pending') {
+          const vmBtn = a.source_ip
+            ? `<button class="btn btn-outline btn-sm" onclick="decideLibrary('${esc(a.host)}','','${esc(a.source_ip)}','approved')" title="Approve for this VM">VM</button>` : '';
+          const globalBtn = (a.skill_id || a.source_ip)
+            ? `<button class="btn btn-outline btn-sm" onclick="decideLibrary('${esc(a.host)}','','','approved')" title="Approve for all agents">Global</button>` : '';
+          actions = `<button class="btn btn-success btn-sm" onclick="decideLibrary('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','approved')">Approve</button>
+             ${vmBtn} ${globalBtn}
+             <button class="btn btn-danger btn-sm" onclick="decideLibrary('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','denied')">Deny</button>
+             ${editBtn} ${deleteBtn}`;
+        } else {
+          const promoteBtn = a.source_ip && !a.skill_id
+            ? `<button class="btn btn-outline btn-sm" onclick="promoteLibraryToGlobal('${esc(a.host)}','${esc(a.source_ip)}','${a.status}')" title="Promote to global rule">Promote to Global</button>` : '';
+          actions = `<button class="btn btn-outline btn-sm" onclick="decideLibrary('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','approved')">Approve</button>
+             <button class="btn btn-outline btn-sm" onclick="decideLibrary('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','denied')">Deny</button>
+             ${promoteBtn}
+             ${editBtn} ${deleteBtn}`;
+        }
+        rows.push(`<tr>
+          <td class="cb-col"><input type="checkbox" class="row-cb" data-key="${esc(key)}" ${cbChecked} onchange="toggleSelect('library',this)"></td>
+          <td><strong>${nameDisplay}</strong></td>
+          <td>${typeDisplay}</td>
+          <td>${categoryDisplay}</td>
+          <td>${skillDisplay}</td>
+          <td>${sourceDisplay}</td>
+          <td><span class="badge-status ${a.status}">${a.status}</span></td>
+          <td>${timeAgo(a.updated_at)}</td>
+          <td>${actions}</td>
+        </tr>`);
+      });
     }
-    filtered.sort((a, b) => getLibraryName(a.host).localeCompare(getLibraryName(b.host)));
-    filtered.forEach((a) => {
-      const key = imgKey(a);
-      const cbChecked = selectedLibraries.has(key) ? 'checked' : '';
-      const idx = currentLibraries.indexOf(a);
-      const skillDisplay = formatSkillID(a.skill_id);
-      const sourceDisplay = formatSourceIP(a.source_ip);
-      const categoryDisplay = formatCategory(a.category);
-      const typeDisplay = formatLibraryType(a.host);
-      const nameDisplay = formatLibraryName(a.host);
-      const editBtn = `<button class="btn btn-outline btn-sm" onclick="showEditLibraryRule(${idx})" title="Edit rule">Edit</button>`;
-      const deleteBtn = `<button class="btn btn-danger btn-sm" onclick="deleteLibrary('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}')" title="Delete rule">Delete</button>`;
-      let actions = '';
-      if (a.status === 'pending') {
-        const vmBtn = a.source_ip
-          ? `<button class="btn btn-outline btn-sm" onclick="decideLibrary('${esc(a.host)}','','${esc(a.source_ip)}','approved')" title="Approve for this VM">VM</button>` : '';
-        const globalBtn = (a.skill_id || a.source_ip)
-          ? `<button class="btn btn-outline btn-sm" onclick="decideLibrary('${esc(a.host)}','','','approved')" title="Approve for all agents">Global</button>` : '';
-        actions = `<button class="btn btn-success btn-sm" onclick="decideLibrary('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','approved')">Approve</button>
-           ${vmBtn} ${globalBtn}
-           <button class="btn btn-danger btn-sm" onclick="decideLibrary('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','denied')">Deny</button>
-           ${editBtn} ${deleteBtn}`;
-      } else {
-        const promoteBtn = a.source_ip && !a.skill_id
-          ? `<button class="btn btn-outline btn-sm" onclick="promoteLibraryToGlobal('${esc(a.host)}','${esc(a.source_ip)}','${a.status}')" title="Promote to global rule">Promote to Global</button>` : '';
-        actions = `<button class="btn btn-outline btn-sm" onclick="decideLibrary('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','approved')">Approve</button>
-           <button class="btn btn-outline btn-sm" onclick="decideLibrary('${esc(a.host)}','${esc(a.skill_id)}','${esc(a.source_ip)}','denied')">Deny</button>
-           ${promoteBtn}
-           ${editBtn} ${deleteBtn}`;
-      }
-      tbody.innerHTML += `<tr>
-        <td class="cb-col"><input type="checkbox" class="row-cb" data-key="${esc(key)}" ${cbChecked} onchange="toggleSelect('library',this)"></td>
-        <td><strong>${nameDisplay}</strong></td>
-        <td>${typeDisplay}</td>
-        <td>${categoryDisplay}</td>
-        <td>${skillDisplay}</td>
-        <td>${sourceDisplay}</td>
-        <td><span class="badge-status ${a.status}">${a.status}</span></td>
-        <td>${timeAgo(a.updated_at)}</td>
-        <td>${actions}</td>
-      </tr>`;
-    });
+    tbody.innerHTML = rows.join('');
     updateBulkBar('library');
+    renderPager('library');
   } catch (e) {
     console.error('Libraries load error:', e);
   }
@@ -1625,7 +1691,6 @@ async function loadLogs() {
       api('GET', '/api/logs?limit=200'),
       refreshSkills(),
       refreshCategories(),
-      (async () => { try { currentApprovals = await api('GET', '/api/approvals') || []; } catch (e) {} })(),
     ]);
     currentLogs = logs || [];
     if (currentLogs.length > 0) lastLogID = currentLogs[0].id;
@@ -1698,19 +1763,25 @@ function formatHeaders(headers) {
 }
 
 // --- Polling ---
+let lastPendingCounts = { approvals: -1, images: -1, packages: -1, libraries: -1 };
+
 function startPolling() {
   pollInterval = setInterval(async () => {
     try {
-      const [pending, pendingImages, pendingPkgs, pendingLibs] = await Promise.all([
-        api('GET', '/api/approvals/pending'),
-        api('GET', '/api/images/pending'),
-        api('GET', '/api/packages/pending'),
-        api('GET', '/api/libraries/pending'),
-      ]);
-      updateBadge('approval-badge', pending);
-      updateBadge('image-badge', pendingImages);
-      updateBadge('package-badge', pendingPkgs);
-      updateBadge('library-badge', pendingLibs);
+      // Use lightweight pending counts endpoint instead of fetching full lists.
+      const counts = await api('GET', '/api/pending-counts');
+      updateBadgeCount('approval-badge', counts.approvals || 0);
+      updateBadgeCount('image-badge', counts.images || 0);
+      updateBadgeCount('package-badge', counts.packages || 0);
+      updateBadgeCount('library-badge', counts.libraries || 0);
+
+      // Only refresh active page if pending counts changed.
+      const changed = counts.approvals !== lastPendingCounts.approvals ||
+        counts.images !== lastPendingCounts.images ||
+        counts.packages !== lastPendingCounts.packages ||
+        counts.libraries !== lastPendingCounts.libraries;
+      lastPendingCounts = { ...counts };
+
       // Poll new logs
       if (document.getElementById('page-logs').classList.contains('active')) {
         const newLogs = await api('GET', '/api/logs?after=' + lastLogID);
@@ -1721,23 +1792,40 @@ function startPolling() {
           renderLogs();
         }
       }
-      // Refresh dashboard or images page if active
-      if (document.getElementById('page-dashboard').classList.contains('active')) {
-        loadDashboard();
-      }
-      if (document.getElementById('page-images').classList.contains('active')) {
-        loadImages();
-      }
-      if (document.getElementById('page-packages').classList.contains('active')) {
-        loadPackages();
-      }
-      if (document.getElementById('page-libraries').classList.contains('active')) {
-        loadLibraries();
+
+      // Only refresh active rule pages if counts changed (new pending items arrived).
+      if (changed) {
+        if (document.getElementById('page-dashboard').classList.contains('active')) {
+          loadDashboard();
+        }
+        if (document.getElementById('page-approvals').classList.contains('active')) {
+          loadApprovals();
+        }
+        if (document.getElementById('page-images').classList.contains('active')) {
+          loadImages();
+        }
+        if (document.getElementById('page-packages').classList.contains('active')) {
+          loadPackages();
+        }
+        if (document.getElementById('page-libraries').classList.contains('active')) {
+          loadLibraries();
+        }
       }
     } catch (e) {
       // Silently ignore poll errors
     }
   }, 3000);
+}
+
+function updateBadgeCount(id, count) {
+  const badge = document.getElementById(id);
+  if (!badge) return;
+  if (count > 0) {
+    badge.textContent = count;
+    badge.style.display = 'inline';
+  } else {
+    badge.style.display = 'none';
+  }
 }
 
 // --- Utilities ---

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -56,16 +56,16 @@
           <button class="btn btn-primary" onclick="showAddRule()">+ Add Rule</button>
         </div>
         <div class="filter-bar">
-          <select id="filter-url-category" onchange="loadApprovals()">
+          <select id="filter-url-category" onchange="onFilterChange('url')">
             <option value="">All categories</option>
           </select>
-          <select id="filter-url-skill" onchange="loadApprovals()">
+          <select id="filter-url-skill" onchange="onFilterChange('url')">
             <option value="">All skills</option>
           </select>
-          <select id="filter-url-ip" onchange="loadApprovals()">
+          <select id="filter-url-ip" onchange="onFilterChange('url')">
             <option value="">All source IPs</option>
           </select>
-          <select id="filter-url-status" onchange="loadApprovals()">
+          <select id="filter-url-status" onchange="onFilterChange('url')">
             <option value="">All statuses</option>
             <option value="approved">Approved</option>
             <option value="denied">Denied</option>
@@ -88,6 +88,7 @@
               <tr><td colspan="9" class="empty-state">No URL rules</td></tr>
             </tbody>
           </table>
+          <div id="pager-url" class="pager" style="display:none"></div>
         </div>
       </div>
 
@@ -98,16 +99,16 @@
           <button class="btn btn-primary" onclick="showAddImageRule()">+ Add Image Rule</button>
         </div>
         <div class="filter-bar">
-          <select id="filter-image-category" onchange="loadImages()">
+          <select id="filter-image-category" onchange="onFilterChange('image')">
             <option value="">All categories</option>
           </select>
-          <select id="filter-image-skill" onchange="loadImages()">
+          <select id="filter-image-skill" onchange="onFilterChange('image')">
             <option value="">All skills</option>
           </select>
-          <select id="filter-image-ip" onchange="loadImages()">
+          <select id="filter-image-ip" onchange="onFilterChange('image')">
             <option value="">All source IPs</option>
           </select>
-          <select id="filter-image-status" onchange="loadImages()">
+          <select id="filter-image-status" onchange="onFilterChange('image')">
             <option value="">All statuses</option>
             <option value="approved">Approved</option>
             <option value="denied">Denied</option>
@@ -130,6 +131,7 @@
               <tr><td colspan="7" class="empty-state">No image approval records</td></tr>
             </tbody>
           </table>
+          <div id="pager-image" class="pager" style="display:none"></div>
         </div>
       </div>
 
@@ -140,19 +142,19 @@
           <button class="btn btn-primary" onclick="showAddPackageRule()">+ Add Package Rule</button>
         </div>
         <div class="filter-bar">
-          <select id="filter-package-type" onchange="loadPackages()">
+          <select id="filter-package-type" onchange="onFilterChange('package')">
             <option value="">All types</option>
           </select>
-          <select id="filter-package-category" onchange="loadPackages()">
+          <select id="filter-package-category" onchange="onFilterChange('package')">
             <option value="">All categories</option>
           </select>
-          <select id="filter-package-skill" onchange="loadPackages()">
+          <select id="filter-package-skill" onchange="onFilterChange('package')">
             <option value="">All skills</option>
           </select>
-          <select id="filter-package-ip" onchange="loadPackages()">
+          <select id="filter-package-ip" onchange="onFilterChange('package')">
             <option value="">All source IPs</option>
           </select>
-          <select id="filter-package-status" onchange="loadPackages()">
+          <select id="filter-package-status" onchange="onFilterChange('package')">
             <option value="">All statuses</option>
             <option value="approved">Approved</option>
             <option value="denied">Denied</option>
@@ -175,6 +177,7 @@
               <tr><td colspan="8" class="empty-state">No OS package approval records</td></tr>
             </tbody>
           </table>
+          <div id="pager-package" class="pager" style="display:none"></div>
         </div>
       </div>
 
@@ -185,19 +188,19 @@
           <button class="btn btn-primary" onclick="showAddLibraryRule()">+ Add Library Rule</button>
         </div>
         <div class="filter-bar">
-          <select id="filter-library-type" onchange="loadLibraries()">
+          <select id="filter-library-type" onchange="onFilterChange('library')">
             <option value="">All types</option>
           </select>
-          <select id="filter-library-category" onchange="loadLibraries()">
+          <select id="filter-library-category" onchange="onFilterChange('library')">
             <option value="">All categories</option>
           </select>
-          <select id="filter-library-skill" onchange="loadLibraries()">
+          <select id="filter-library-skill" onchange="onFilterChange('library')">
             <option value="">All skills</option>
           </select>
-          <select id="filter-library-ip" onchange="loadLibraries()">
+          <select id="filter-library-ip" onchange="onFilterChange('library')">
             <option value="">All source IPs</option>
           </select>
-          <select id="filter-library-status" onchange="loadLibraries()">
+          <select id="filter-library-status" onchange="onFilterChange('library')">
             <option value="">All statuses</option>
             <option value="approved">Approved</option>
             <option value="denied">Denied</option>
@@ -220,6 +223,7 @@
               <tr><td colspan="8" class="empty-state">No code library approval records</td></tr>
             </tbody>
           </table>
+          <div id="pager-library" class="pager" style="display:none"></div>
         </div>
       </div>
 

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -353,3 +353,33 @@ th.cb-col input, td.cb-col input { cursor: pointer; accent-color: var(--accent);
   color: var(--text);
   margin-right: 4px;
 }
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  font-size: 13px;
+  color: var(--text-dim);
+  border-top: 1px solid var(--border);
+}
+.pager-buttons {
+  display: flex;
+  gap: 6px;
+}
+.pager-buttons button {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+}
+.pager-buttons button:hover:not(:disabled) {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.pager-buttons button:disabled {
+  opacity: 0.3;
+  cursor: default;
+}


### PR DESCRIPTION
## Summary

- Add server-side filtering and pagination to all rule list API endpoints (URLs, images, packages, libraries) — responses now return `{items, total}` with offset/limit support, reducing JSON payload from potentially thousands of items to 50 per page
- Add lightweight `/api/pending-counts` endpoint returning just 4 integers, replacing 4 separate full pending list fetches during the 3-second polling cycle
- Add `/api/*/meta` endpoints for populating filter dropdowns without transferring full datasets
- Polling now skips page refreshes when pending counts haven't changed, eliminating unnecessary DOM rebuilds
- Frontend rendering uses array `.join('')` instead of repeated `innerHTML +=` concatenation

## Test plan

- [x] All existing tests pass (`go test ./...` and `go vet`)
- [ ] Verify URL rules page loads with pagination controls when >50 rules exist
- [ ] Verify filter dropdowns populate correctly from `/meta` endpoints
- [ ] Verify Previous/Next pagination buttons work and show correct counts
- [ ] Verify sidebar badges still update correctly via lightweight polling
- [ ] Verify bulk actions still work across filtered/paginated views
- [ ] Verify edit modal still works (uses index into current page items)
- [ ] Backward compatibility: API without query params still returns full array

https://claude.ai/code/session_014tUnc94exxPy425gG1AtVD