### PR TITLE
Add build log download and version deletion features

### DIFF
--- a/internal/image/build.go
+++ b/internal/image/build.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -719,15 +718,14 @@ func getBuildLogger() *BuildLogger {
 func cmdOutput() (io.Writer, io.Writer) {
 	bl := getBuildLogger()
 	if bl != nil {
-		return io.MultiWriter(os.Stdout, bl), io.MultiWriter(os.Stderr, bl)
+		return bl, bl
 	}
-	return os.Stdout, os.Stderr
+	return io.Discard, io.Discard
 }
 
-// buildLog logs a message to both Go's standard logger and the active build logger.
+// buildLog logs a message to the active build logger only.
 func buildLog(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	log.Print(msg)
 	bl := getBuildLogger()
 	if bl != nil {
 		bl.mu.Lock()

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -2679,6 +2679,10 @@ async function showBuildLog(imageId, version, status) {
   document.getElementById('build-log-content').textContent = 'Loading...';
   document.getElementById('modal-build-log').classList.add('active');
 
+  // Hide delete button while build is active.
+  const deleteBtn = document.getElementById('build-log-delete-btn');
+  deleteBtn.style.display = (status === 'building' || status === 'pending') ? 'none' : '';
+
   await refreshBuildLog();
 
   // Auto-refresh while building.
@@ -2703,6 +2707,7 @@ async function refreshBuildLog() {
       const ver = (img.versions || []).find(v => v.version === buildLogVersion);
       if (ver && ver.status !== 'building' && ver.status !== 'pending') {
         stopBuildLogRefresh();
+        document.getElementById('build-log-delete-btn').style.display = '';
         loadDiskImages();
       }
     }
@@ -2723,6 +2728,31 @@ function hideBuildLog() {
   document.getElementById('modal-build-log').classList.remove('active');
   buildLogImageId = null;
   buildLogVersion = null;
+}
+
+function downloadBuildLog() {
+  const content = document.getElementById('build-log-content').textContent;
+  const blob = new Blob([content], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `build-log-${buildLogImageId}-v${buildLogVersion}.txt`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+async function deleteVersionFromLog() {
+  if (!buildLogImageId || buildLogVersion == null) return;
+  if (!confirm(`Delete version ${buildLogVersion} of this disk image?`)) return;
+  try {
+    await api('DELETE', `/api/disk-images/version?id=${encodeURIComponent(buildLogImageId)}&version=${buildLogVersion}`);
+    hideBuildLog();
+    loadDiskImages();
+  } catch (e) {
+    alert('Failed to delete version: ' + e.message);
+  }
 }
 
 // --- Agent VMs ---

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -982,6 +982,8 @@
       <h3>Build Log</h3>
       <pre id="build-log-content" style="background:var(--bg-secondary);padding:12px;border-radius:6px;max-height:60vh;overflow-y:auto;font-size:12px;white-space:pre-wrap;word-break:break-all"></pre>
       <div class="modal-actions">
+        <button class="btn btn-outline" onclick="downloadBuildLog()">Download Log</button>
+        <button class="btn btn-danger" id="build-log-delete-btn" onclick="deleteVersionFromLog()">Delete Version</button>
         <button class="btn btn-outline" onclick="hideBuildLog()">Close</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
This PR adds functionality to download build logs and delete disk image versions directly from the build log modal, while also improving logging behavior in the build system.

## Key Changes

**Frontend (web/static/)**
- Added "Download Log" button to export build logs as text files with descriptive naming (`build-log-{imageId}-v{version}.txt`)
- Added "Delete Version" button to remove disk image versions from the build log modal
- Implemented delete button visibility logic: hidden during active builds (pending/building status), shown when build completes
- Delete button is re-enabled after build completion in the auto-refresh handler

**Backend (internal/image/build.go)**
- Removed redundant logging to Go's standard logger in `buildLog()` function - now logs only to the active build logger
- Simplified `cmdOutput()` to return only the build logger output (or `io.Discard` if unavailable) instead of multiplexing to both stdout/stderr and the build logger
- Removed unused `log` import

## Implementation Details
- Build log download creates a client-side blob and triggers browser download without server interaction
- Delete operation calls the existing `/api/disk-images/version` DELETE endpoint and refreshes the image list
- The delete button state is managed in two places: initial modal display and after build completion
- Logging changes consolidate output to a single destination, reducing duplicate log entries

https://claude.ai/code/session_01YbaEYQ6yQEnjEqG5bACqUw