### PR TITLE
Add bulk category assignment for URLs, images, packages, and libraries

### DIFF
--- a/web/static/app.js
+++ b/web/static/app.js
@@ -507,6 +507,48 @@ async function bulkAction(prefix, action) {
   if (activePage) navigate(activePage.id.replace('page-', ''));
 }
 
+function populateBulkCategorySelects() {
+  ['url', 'image', 'package', 'library'].forEach(prefix => {
+    const el = document.getElementById('bulk-category-' + prefix);
+    if (!el) return;
+    const current = el.value;
+    el.innerHTML = '<option value="">No category</option>';
+    currentCategories.forEach(c => {
+      const o = document.createElement('option');
+      o.value = c;
+      o.textContent = c;
+      el.appendChild(o);
+    });
+    if (current && [...el.options].some(o => o.value === current)) {
+      el.value = current;
+    }
+  });
+}
+
+async function bulkSetCategory(prefix) {
+  const set = getSelectionSet(prefix);
+  if (set.size === 0) return;
+  const categoryEl = document.getElementById('bulk-category-' + prefix);
+  if (!categoryEl) return;
+  const category = categoryEl.value;
+  const items = getCurrentFiltered(prefix);
+  const keyFn = getKeyFn(prefix);
+  const selectedItems = items.filter(a => set.has(keyFn(a)));
+  if (selectedItems.length === 0) return;
+  const label = category ? `Set category to "${category}"` : 'Remove category from';
+  if (!confirm(`${label} ${selectedItems.length} selected item(s)?`)) return;
+  const apiPath = { url: '/api/approvals/category', image: '/api/images/category', package: '/api/packages/category', library: '/api/libraries/category' }[prefix];
+  try {
+    for (const a of selectedItems) {
+      const pp = prefix === 'url' ? (a.path_prefix || '') : '';
+      await api('PUT', apiPath, { host: a.host, skill_id: a.skill_id || '', source_ip: a.source_ip || '', path_prefix: pp, category });
+    }
+  } catch (e) { alert('Error: ' + e.message); return; }
+  set.clear();
+  const activePage = document.querySelector('.page.active');
+  if (activePage) navigate(activePage.id.replace('page-', ''));
+}
+
 function formatCategory(category) {
   if (!category) return '<span class="badge-status" style="opacity:0.4">-</span>';
   return '<span class="category-badge">' + esc(category) + '</span>';
@@ -566,6 +608,7 @@ async function refreshCategories() {
   } catch (e) {
     currentCategories = [];
   }
+  populateBulkCategorySelects();
 }
 
 async function refreshSkills() {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -109,6 +109,8 @@
           <button class="btn btn-success btn-sm" onclick="bulkAction('url','approve')">Approve</button>
           <button class="btn btn-danger btn-sm" onclick="bulkAction('url','deny')">Deny</button>
           <button class="btn btn-outline btn-sm" onclick="bulkAction('url','promote')">Promote Global</button>
+          <select id="bulk-category-url" class="btn btn-outline btn-sm bulk-category-select" style="min-width:130px"></select>
+          <button class="btn btn-outline btn-sm" onclick="bulkSetCategory('url')">Set Category</button>
           <button class="btn btn-danger btn-sm" onclick="bulkAction('url','delete')">Delete</button>
           <button class="btn btn-outline btn-sm" onclick="clearSelection('url')">Clear selection</button>
         </div>
@@ -152,6 +154,8 @@
           <button class="btn btn-success btn-sm" onclick="bulkAction('image','approve')">Approve</button>
           <button class="btn btn-danger btn-sm" onclick="bulkAction('image','deny')">Deny</button>
           <button class="btn btn-outline btn-sm" onclick="bulkAction('image','promote')">Promote Global</button>
+          <select id="bulk-category-image" class="btn btn-outline btn-sm bulk-category-select" style="min-width:130px"></select>
+          <button class="btn btn-outline btn-sm" onclick="bulkSetCategory('image')">Set Category</button>
           <button class="btn btn-danger btn-sm" onclick="bulkAction('image','delete')">Delete</button>
           <button class="btn btn-outline btn-sm" onclick="clearSelection('image')">Clear selection</button>
         </div>
@@ -198,6 +202,8 @@
           <button class="btn btn-success btn-sm" onclick="bulkAction('package','approve')">Approve</button>
           <button class="btn btn-danger btn-sm" onclick="bulkAction('package','deny')">Deny</button>
           <button class="btn btn-outline btn-sm" onclick="bulkAction('package','promote')">Promote Global</button>
+          <select id="bulk-category-package" class="btn btn-outline btn-sm bulk-category-select" style="min-width:130px"></select>
+          <button class="btn btn-outline btn-sm" onclick="bulkSetCategory('package')">Set Category</button>
           <button class="btn btn-danger btn-sm" onclick="bulkAction('package','delete')">Delete</button>
           <button class="btn btn-outline btn-sm" onclick="clearSelection('package')">Clear selection</button>
         </div>
@@ -244,6 +250,8 @@
           <button class="btn btn-success btn-sm" onclick="bulkAction('library','approve')">Approve</button>
           <button class="btn btn-danger btn-sm" onclick="bulkAction('library','deny')">Deny</button>
           <button class="btn btn-outline btn-sm" onclick="bulkAction('library','promote')">Promote Global</button>
+          <select id="bulk-category-library" class="btn btn-outline btn-sm bulk-category-select" style="min-width:130px"></select>
+          <button class="btn btn-outline btn-sm" onclick="bulkSetCategory('library')">Set Category</button>
           <button class="btn btn-danger btn-sm" onclick="bulkAction('library','delete')">Delete</button>
           <button class="btn btn-outline btn-sm" onclick="clearSelection('library')">Clear selection</button>
         </div>


### PR DESCRIPTION
## Summary
This PR adds the ability to bulk assign categories to selected items across all approval sections (URLs, images, packages, and libraries). Users can now select multiple items and set or remove their category in a single operation.

## Key Changes
- **New UI Controls**: Added category dropdown selects and "Set Category" buttons to the bulk action toolbars for each approval section (URLs, images, packages, libraries)
- **New Function `bulkSetCategory()`**: Implements the bulk category assignment logic, including:
  - Retrieves selected items based on the prefix
  - Validates that items are selected
  - Prompts user for confirmation before applying changes
  - Makes API calls to update categories for all selected items
  - Refreshes the current page after successful update
- **New Function `populateBulkCategorySelects()`**: Populates all category dropdowns with available categories from `currentCategories`, preserving the current selection when possible
- **Integration with `refreshCategories()`**: Automatically repopulates category selects whenever categories are refreshed

## Implementation Details
- The category assignment supports removing categories by selecting the "No category" option
- API endpoints used: `/api/approvals/category`, `/api/images/category`, `/api/packages/category`, `/api/libraries/category`
- The implementation reuses existing patterns like `getSelectionSet()`, `getCurrentFiltered()`, and `getKeyFn()` for consistency
- URL items include special handling for `path_prefix` when making API calls

https://claude.ai/code/session_01CcgX3YX2kEu3sDhSJwamfK