### PR TITLE
Auto-approve CONNECT requests for configured repository hosts

### DIFF
--- a/internal/library/library.go
+++ b/internal/library/library.go
@@ -414,8 +414,14 @@ func MatchPackageRef(pattern, pkg string) bool {
 	if pattern == pkg {
 		return true
 	}
+	// Prefix wildcard with /: "github.com/gorilla/*" matches "github.com/gorilla/mux"
 	if strings.HasSuffix(pattern, "/*") {
 		prefix := pattern[:len(pattern)-1] // include trailing /
+		return strings.HasPrefix(pkg, prefix)
+	}
+	// Trailing wildcard: "helm:kube-*" matches "helm:kube-prometheus-stack"
+	if strings.HasSuffix(pattern, "*") {
+		prefix := pattern[:len(pattern)-1]
 		return strings.HasPrefix(pkg, prefix)
 	}
 	return false

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -83,6 +83,26 @@ func New(skills *auth.SkillStore, approvals *approval.Manager, creds *credential
 }
 
 // statusToHTTPCode maps an approval status to the appropriate HTTP status code.
+// isConfiguredRepoHost returns true if the host belongs to a configured
+// container registry, Helm chart repo, OS package repo, or code library repo.
+// These hosts are auto-approved at the CONNECT level when MITM is available,
+// since the real access control happens per-item inside the tunnel.
+func (p *Proxy) isConfiguredRepoHost(host string) bool {
+	if registry.RegistryForHost(host, p.Registries) != nil {
+		return true
+	}
+	if library.RepoForHost(host, p.HelmRepos) != nil {
+		return true
+	}
+	if library.RepoForHost(host, p.OSPackages) != nil {
+		return true
+	}
+	if library.RepoForHost(host, p.CodeLibraries) != nil {
+		return true
+	}
+	return false
+}
+
 // StatusDenied -> 403 Forbidden, StatusPendingTimeout -> 407 Proxy Authentication Required.
 func statusToHTTPCode(status approval.Status) int {
 	if status == approval.StatusPendingTimeout {
@@ -597,11 +617,16 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// For CONNECT with MITM, check if any approval (host-only or path-specific)
-	// exists. Per-request path checks happen in handleMITMRequest.
+	// For CONNECT with MITM, auto-approve hosts that belong to configured
+	// infrastructure (registries, Helm repos, package repos, code libraries)
+	// since the real access control happens per-item inside the tunnel.
+	// For other hosts, check host-level approval. Per-request path checks
+	// happen in handleMITMRequest.
 	// For blind tunnels (no MITM), use host-only check since we can't inspect paths.
 	var status approval.Status
-	if p.CA != nil {
+	if p.CA != nil && p.isConfiguredRepoHost(host) {
+		status = approval.StatusApproved
+	} else if p.CA != nil {
 		status = p.checkHostApproval(host, skill, sourceIP)
 	} else {
 		status = p.checkApproval(host, "", skill, sourceIP)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -21,6 +21,19 @@ import (
 	proxylog "github.com/olljanat-ai/firewall4ai/internal/logging"
 )
 
+// testRedirectTransport wraps an http.RoundTripper and rewrites every
+// request URL so that it is sent to the given target host (e.g. the
+// httptest.Server address) instead of the host the proxy handler set.
+type testRedirectTransport struct {
+	inner      http.RoundTripper
+	targetHost string // host:port of the test backend
+}
+
+func (t *testRedirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Host = t.targetHost
+	return t.inner.RoundTrip(req)
+}
+
 func setupProxy(t *testing.T) (*Proxy, *auth.SkillStore, *approval.Manager) {
 	t.Helper()
 	skills := auth.NewSkillStore()
@@ -983,7 +996,8 @@ func TestProxy_HelmChart_CertManager_Approved(t *testing.T) {
 	p.HelmRepos = []config.PackageRepoConfig{
 		{Name: "Jetstack", Type: "helm", Hosts: []string{"charts.jetstack.io"}},
 	}
-	p.Transport = backend.Client().Transport
+	backendURL, _ := url.Parse(backend.URL)
+	p.Transport = &testRedirectTransport{inner: backend.Client().Transport, targetHost: backendURL.Host}
 
 	// Pre-approve cert-manager.
 	p.HelmChartApprovals.Decide("helm:cert-manager", "", "", "", approval.StatusApproved, "")
@@ -1074,7 +1088,8 @@ func TestProxy_HelmChart_IndexYaml_AutoApproved(t *testing.T) {
 	p.HelmRepos = []config.PackageRepoConfig{
 		{Name: "Jetstack", Type: "helm", Hosts: []string{"charts.jetstack.io"}},
 	}
-	p.Transport = backend.Client().Transport
+	backendURL, _ := url.Parse(backend.URL)
+	p.Transport = &testRedirectTransport{inner: backend.Client().Transport, targetHost: backendURL.Host}
 
 	req, _ := http.NewRequest("GET", "https://charts.jetstack.io:443/index.yaml", nil)
 	req.Host = "charts.jetstack.io"
@@ -1116,7 +1131,8 @@ func TestProxy_HelmChart_LearningMode_CertManager(t *testing.T) {
 		{Name: "Jetstack", Type: "helm", Hosts: []string{"charts.jetstack.io"}},
 	}
 	p.LearningMode = true
-	p.Transport = backend.Client().Transport
+	backendURL, _ := url.Parse(backend.URL)
+	p.Transport = &testRedirectTransport{inner: backend.Client().Transport, targetHost: backendURL.Host}
 
 	req, _ := http.NewRequest("GET", "https://charts.jetstack.io:443/charts/cert-manager-v1.14.0.tgz", nil)
 	req.Host = "charts.jetstack.io"


### PR DESCRIPTION
## Summary
This PR implements auto-approval for CONNECT requests to configured infrastructure hosts (container registries, Helm repos, OS package repos, and code libraries) when MITM is available. Since access control for these hosts happens per-item inside the tunnel, host-level approval is not necessary.

## Key Changes
- **Auto-approval logic**: Added `isConfiguredRepoHost()` method to check if a host belongs to any configured repository type (registries, Helm repos, OS packages, or code libraries)
- **CONNECT handler update**: Modified `handleConnect()` to auto-approve configured repo hosts when MITM is available, while maintaining host-level approval checks for other hosts
- **Test infrastructure**: Added `testRedirectTransport` helper to properly redirect test requests to the httptest backend server
- **Test updates**: Updated three Helm chart tests to use the new `testRedirectTransport` for correct request routing
- **Pattern matching enhancement**: Extended `MatchPackageRef()` to support trailing wildcard patterns (e.g., "helm:kube-*") in addition to existing prefix wildcards

## Implementation Details
- The auto-approval only applies when MITM is enabled (`p.CA != nil`) and the host is in a configured repository
- Blind tunnels (without MITM) continue to use host-only approval checks
- Per-request path-level checks still occur in `handleMITMRequest()` for configured repo hosts
- The `testRedirectTransport` wrapper ensures test requests reach the correct backend by rewriting the request URL host while preserving the original transport behavior

https://claude.ai/code/session_018P3puHLbYR1MyTtdvzfUyH