### PR TITLE
Add support for Qwen Code AI tool installation

### DIFF
--- a/internal/image/build.go
+++ b/internal/image/build.go
@@ -892,7 +892,7 @@ func installAITools(img *DiskImage, rootfsDir string, isDebian bool, debEnv []st
 	needsCurl := false
 	for _, tool := range img.AITools {
 		switch tool {
-		case AIToolOpenCode, AIToolClaudeCode, AIToolOpenAICodex:
+		case AIToolOpenCode, AIToolClaudeCode, AIToolOpenAICodex, AIToolQwenCode:
 			needsNodeJS = true
 		case AIToolGitHubCopilot:
 			needsCurl = true
@@ -948,6 +948,12 @@ func installAITools(img *DiskImage, rootfsDir string, isDebian bool, debEnv []st
 			buildLog("Image build [%s v%s]: installing OpenAI Codex", img.Name, img.OSVersion)
 			if err := runChroot(rootfsDir, "npm", "install", "-g", "@openai/codex"); err != nil {
 				return fmt.Errorf("install OpenAI Codex: %w", err)
+			}
+
+		case AIToolQwenCode:
+			buildLog("Image build [%s v%s]: installing Qwen Code", img.Name, img.OSVersion)
+			if err := runChroot(rootfsDir, "npm", "install", "-g", "@qwen-code/qwen-code"); err != nil {
+				return fmt.Errorf("install Qwen Code: %w", err)
 			}
 
 		case AIToolGitHubCopilot:

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -41,6 +41,7 @@ const (
 	AIToolGitHubCopilot AITool = "github_copilot"
 	AIToolClaudeCode    AITool = "claude_code"
 	AIToolOpenAICodex   AITool = "openai_codex"
+	AIToolQwenCode      AITool = "qwen_code"
 )
 
 // ContainerTool represents a container runtime that can be installed.

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -2685,7 +2685,8 @@ async function loadDiskImages() {
       'opencode': 'OpenCode',
       'github_copilot': 'GitHub Copilot',
       'claude_code': 'Claude Code',
-      'openai_codex': 'OpenAI Codex'
+      'openai_codex': 'OpenAI Codex',
+      'qwen_code': 'Qwen Code'
     };
     const containerToolLabels = {
       'docker': 'Docker',
@@ -2827,6 +2828,7 @@ function editDiskImage(id) {
   else if (aiTools.includes('github_copilot')) document.getElementById('disk-image-ai-github-copilot').checked = true;
   else if (aiTools.includes('claude_code')) document.getElementById('disk-image-ai-claude-code').checked = true;
   else if (aiTools.includes('openai_codex')) document.getElementById('disk-image-ai-openai-codex').checked = true;
+  else if (aiTools.includes('qwen_code')) document.getElementById('disk-image-ai-qwen-code').checked = true;
   else document.getElementById('disk-image-ai-none').checked = true;
   const ctTools = img.container_tools || [];
   if (ctTools.includes('nomad')) document.getElementById('disk-image-ct-nomad').checked = true;

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -1085,6 +1085,7 @@
           <label class="checkbox-label"><input type="radio" name="disk-image-ai-tool" id="disk-image-ai-github-copilot" value="github_copilot"> GitHub Copilot</label>
           <label class="checkbox-label"><input type="radio" name="disk-image-ai-tool" id="disk-image-ai-claude-code" value="claude_code"> Claude Code</label>
           <label class="checkbox-label"><input type="radio" name="disk-image-ai-tool" id="disk-image-ai-openai-codex" value="openai_codex"> OpenAI Codex</label>
+          <label class="checkbox-label"><input type="radio" name="disk-image-ai-tool" id="disk-image-ai-qwen-code" value="qwen_code"> Qwen Code</label>
         </div>
       </div>
       <div class="form-group">


### PR DESCRIPTION
## Summary
This PR adds support for installing and configuring Qwen Code as an AI tool option alongside existing tools like GitHub Copilot, Claude Code, and OpenAI Codex.

## Key Changes
- **Backend (image.go)**: Added `AIToolQwenCode` constant with value `"qwen_code"` to the AITool type
- **Build Logic (build.go)**: 
  - Added `AIToolQwenCode` to the Node.js dependency check (alongside OpenCode, Claude Code, and OpenAI Codex)
  - Implemented installation case for Qwen Code that uses npm to install the `@qwen-code/qwen-code` package
- **Frontend (index.html)**: Added radio button option for Qwen Code in the disk image AI tool selection form
- **Frontend (app.js)**:
  - Added `'qwen_code': 'Qwen Code'` to the AI tool labels mapping
  - Added checkbox handling for Qwen Code in the disk image edit function

## Implementation Details
The Qwen Code installation follows the same pattern as other npm-based AI tools (OpenCode, Claude Code, OpenAI Codex), requiring Node.js to be installed as a prerequisite. The tool is installed globally via npm within the chroot environment during image build.

https://claude.ai/code/session_01M5hrVVT7nXB3ru5v51wcvF