### PR TITLE
Implement repo-level Helm chart approvals with wildcard support

### DIFF
--- a/config/firewall4ai/config.json
+++ b/config/firewall4ai/config.json
@@ -17,7 +17,8 @@
   "helm_repos": [
     {"name": "Jetstack", "type": "helm", "hosts": ["charts.jetstack.io"]},
     {"name": "Bitnami", "type": "helm", "hosts": ["charts.bitnami.com"]},
-    {"name": "Ingress NGINX", "type": "helm", "hosts": ["kubernetes.github.io"]}
+    {"name": "Ingress NGINX", "type": "helm", "hosts": ["kubernetes.github.io"]},
+    {"name": "Rancher", "type": "helm", "hosts": ["releases.rancher.com"]}
   ],
   "os_packages": [
     {"name": "Debian", "type": "debian", "hosts": ["deb.debian.org", "security.debian.org", "ftp.debian.org", "httpredir.debian.org", "cdn-fastly.deb.debian.org", "metadata.ftp-master.debian.org", "download.docker.com"]},

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1116,6 +1116,9 @@ func (p *Proxy) handleRegistryTLSRequest(clientConn net.Conn, req *http.Request,
 
 // checkHelmChartRepoAccess parses the Helm chart name from the URL and runs
 // the approval logic using the HelmChartApprovals manager.
+// Refs use the format "helm:<host>" for repo-level (metadata) requests and
+// "helm:<host>/<chartName>" for chart-specific requests. Approving a repo
+// with wildcard "helm:<host>/*" auto-approves all charts from that repo.
 func (p *Proxy) checkHelmChartRepoAccess(req *http.Request, host, sourceIP string, skill *auth.Skill, repo *config.PackageRepoConfig, start time.Time) (deniedStatus approval.Status, resource string) {
 	sid := getSkillID(skill)
 	urlPath := req.URL.Path
@@ -1135,38 +1138,40 @@ func (p *Proxy) checkHelmChartRepoAccess(req *http.Request, host, sourceIP strin
 		})
 		return "", ""
 	}
+
+	// Build the approval ref. Metadata (index.yaml) uses "helm:<host>",
+	// chart-specific requests use "helm:<host>/<chartName>".
+	var ref string
 	if chartName == "" {
-		// Metadata request (index.yaml, etc.) — auto-approve.
-		p.Logger.Add(proxylog.Entry{
-			SkillID:  sid,
-			Method:   req.Method,
-			Host:     host,
-			Path:     urlPath,
-			Status:   "allowed",
-			Detail:   "helm metadata (" + repo.Name + ")",
-			Duration: time.Since(start).Milliseconds(),
-		})
-		return "", ""
+		ref = "helm:" + host
+	} else {
+		ref = "helm:" + host + "/" + chartName
 	}
 
-	// Chart-specific request — check approval.
-	ref := "helm:" + chartName
-	if !p.LearningMode && library.CheckPackageApproval(p.HelmChartApprovals, ref) {
+	if !p.LearningMode && checkHelmApprovalFastPath(p.HelmChartApprovals, ref) {
 		// already approved — fast path
 	} else {
 		status := p.checkHelmChartApproval(ref, skill, sourceIP)
 		if status != approval.StatusApproved {
-			resource = "helm chart " + chartName
+			if chartName == "" {
+				resource = "Helm repo " + repo.Name + " (" + host + ")"
+			} else {
+				resource = "Helm chart " + host + "/" + chartName
+			}
 			p.Logger.Add(proxylog.Entry{
 				SkillID: sid,
 				Method:  req.Method,
 				Host:    host,
 				Path:    urlPath,
 				Status:  string(status),
-				Detail:  "helm chart not approved: " + ref,
+				Detail:  "helm not approved: " + ref,
 			})
 			return status, resource
 		}
+	}
+	detail := ref
+	if chartName == "" {
+		detail = "helm metadata (" + repo.Name + ")"
 	}
 	p.Logger.Add(proxylog.Entry{
 		SkillID:  sid,
@@ -1174,29 +1179,66 @@ func (p *Proxy) checkHelmChartRepoAccess(req *http.Request, host, sourceIP strin
 		Host:     host,
 		Path:     urlPath,
 		Status:   "allowed",
-		Detail:   ref,
+		Detail:   detail,
 		Duration: time.Since(start).Milliseconds(),
 	})
 	return "", ""
 }
 
+// matchHelmRef checks if a stored approval pattern matches a Helm chart reference.
+// Supports:
+//   - Exact match: "helm:host/chart" == "helm:host/chart"
+//   - Wildcard: "helm:host/*" matches "helm:host/chart"
+//   - Repo-level: "helm:host" matches "helm:host/chart" (approving repo covers all charts)
+func matchHelmRef(pattern, ref string) bool {
+	if pattern == ref {
+		return true
+	}
+	// Wildcard: "helm:host/*" matches "helm:host/chart"
+	if strings.HasSuffix(pattern, "/*") {
+		prefix := pattern[:len(pattern)-1] // include trailing /
+		return strings.HasPrefix(ref, prefix)
+	}
+	// Repo-level: approving "helm:host" implicitly covers "helm:host/chart"
+	if !strings.Contains(pattern, "/") && strings.HasPrefix(ref, pattern+"/") {
+		return true
+	}
+	return false
+}
+
+// checkHelmApprovalFastPath returns true if the Helm ref (or a broader pattern)
+// has already been approved.
+func checkHelmApprovalFastPath(mgr *approval.Manager, ref string) bool {
+	// Exact match.
+	if status, ok := mgr.CheckExisting(ref, "", "", ""); ok && status == approval.StatusApproved {
+		return true
+	}
+	// Wildcard/repo-level match.
+	if status, ok := mgr.CheckExistingWithMatcher(ref, "", "", matchHelmRef); ok && status == approval.StatusApproved {
+		return true
+	}
+	return false
+}
+
 // checkHelmChartApproval performs three-level approval for a Helm chart.
+// Uses matchHelmRef which supports wildcard patterns ("helm:host/*") and
+// repo-level approval (approving "helm:host" implicitly covers "helm:host/chart").
 func (p *Proxy) checkHelmChartApproval(ref string, skill *auth.Skill, sourceIP string) approval.Status {
 	sid := getSkillID(skill)
 
 	// 1. Global.
-	if status, ok := p.HelmChartApprovals.CheckExistingWithMatcher(ref, "", "", library.MatchPackageRef); ok && status != approval.StatusPending {
+	if status, ok := p.HelmChartApprovals.CheckExistingWithMatcher(ref, "", "", matchHelmRef); ok && status != approval.StatusPending {
 		return status
 	}
 	// 2. VM-specific.
 	if sourceIP != "" {
-		if status, ok := p.HelmChartApprovals.CheckExistingWithMatcher(ref, "", sourceIP, library.MatchPackageRef); ok && status != approval.StatusPending {
+		if status, ok := p.HelmChartApprovals.CheckExistingWithMatcher(ref, "", sourceIP, matchHelmRef); ok && status != approval.StatusPending {
 			return status
 		}
 	}
 	// 3. Skill-specific.
 	if sid != "" {
-		if status, ok := p.HelmChartApprovals.CheckExistingWithMatcher(ref, sid, "", library.MatchPackageRef); ok && status != approval.StatusPending {
+		if status, ok := p.HelmChartApprovals.CheckExistingWithMatcher(ref, sid, "", matchHelmRef); ok && status != approval.StatusPending {
 			return status
 		}
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -999,8 +999,8 @@ func TestProxy_HelmChart_CertManager_Approved(t *testing.T) {
 	backendURL, _ := url.Parse(backend.URL)
 	p.Transport = &testRedirectTransport{inner: backend.Client().Transport, targetHost: backendURL.Host}
 
-	// Pre-approve cert-manager.
-	p.HelmChartApprovals.Decide("helm:cert-manager", "", "", "", approval.StatusApproved, "")
+	// Pre-approve cert-manager from Jetstack repo.
+	p.HelmChartApprovals.Decide("helm:charts.jetstack.io/cert-manager", "", "", "", approval.StatusApproved, "")
 
 	req, _ := http.NewRequest("GET", "https://charts.jetstack.io:443/charts/cert-manager-v1.16.2.tgz", nil)
 	req.Host = "charts.jetstack.io"
@@ -1066,17 +1066,65 @@ func TestProxy_HelmChart_CertManager_Denied(t *testing.T) {
 	pending := p.HelmChartApprovals.ListPending()
 	found := false
 	for _, a := range pending {
-		if a.Host == "helm:cert-manager" {
+		if a.Host == "helm:charts.jetstack.io/cert-manager" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Error("expected pending helm chart approval for helm:cert-manager")
+		t.Error("expected pending helm chart approval for helm:charts.jetstack.io/cert-manager")
 	}
 }
 
-func TestProxy_HelmChart_IndexYaml_AutoApproved(t *testing.T) {
+func TestProxy_HelmChart_IndexYaml_CreatesRepoEntry(t *testing.T) {
+	p, _, _ := setupProxy(t)
+	p.HelmChartApprovals = approval.NewManager()
+	p.HelmRepos = []config.PackageRepoConfig{
+		{Name: "Jetstack", Type: "helm", Hosts: []string{"charts.jetstack.io"}},
+	}
+
+	req, _ := http.NewRequest("GET", "https://charts.jetstack.io:443/index.yaml", nil)
+	req.Host = "charts.jetstack.io"
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+
+	repo := &p.HelmRepos[0]
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.handleHelmChartRepoTLSRequest(serverConn, req, "charts.jetstack.io", "10.0.0.1", nil, repo, time.Now())
+		serverConn.Close()
+	}()
+
+	resp, err := http.ReadResponse(bufio.NewReader(clientConn), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+	<-done
+
+	// index.yaml creates a pending repo-level entry (no longer auto-approved).
+	if resp.StatusCode != http.StatusProxyAuthRequired {
+		t.Errorf("index.yaml should create pending entry and return 407, got %d", resp.StatusCode)
+	}
+
+	// Verify pending entry was created for the repo.
+	pending := p.HelmChartApprovals.ListPending()
+	found := false
+	for _, a := range pending {
+		if a.Host == "helm:charts.jetstack.io" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected pending helm chart approval for helm:charts.jetstack.io")
+	}
+}
+
+func TestProxy_HelmChart_IndexYaml_ApprovedRepo(t *testing.T) {
 	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("index data"))
@@ -1090,6 +1138,9 @@ func TestProxy_HelmChart_IndexYaml_AutoApproved(t *testing.T) {
 	}
 	backendURL, _ := url.Parse(backend.URL)
 	p.Transport = &testRedirectTransport{inner: backend.Client().Transport, targetHost: backendURL.Host}
+
+	// Pre-approve the repo.
+	p.HelmChartApprovals.Decide("helm:charts.jetstack.io", "", "", "", approval.StatusApproved, "")
 
 	req, _ := http.NewRequest("GET", "https://charts.jetstack.io:443/index.yaml", nil)
 	req.Host = "charts.jetstack.io"
@@ -1114,7 +1165,52 @@ func TestProxy_HelmChart_IndexYaml_AutoApproved(t *testing.T) {
 	<-done
 
 	if resp.StatusCode != http.StatusOK {
-		t.Errorf("index.yaml should be auto-approved, got %d", resp.StatusCode)
+		t.Errorf("approved repo index.yaml should return 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestProxy_HelmChart_RepoApproval_CoversCharts(t *testing.T) {
+	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("chart data"))
+	}))
+	defer backend.Close()
+
+	p, _, _ := setupProxy(t)
+	p.HelmChartApprovals = approval.NewManager()
+	p.HelmRepos = []config.PackageRepoConfig{
+		{Name: "Jetstack", Type: "helm", Hosts: []string{"charts.jetstack.io"}},
+	}
+	backendURL, _ := url.Parse(backend.URL)
+	p.Transport = &testRedirectTransport{inner: backend.Client().Transport, targetHost: backendURL.Host}
+
+	// Approve the repo — this should cover all charts from it.
+	p.HelmChartApprovals.Decide("helm:charts.jetstack.io", "", "", "", approval.StatusApproved, "")
+
+	req, _ := http.NewRequest("GET", "https://charts.jetstack.io:443/charts/cert-manager-v1.16.2.tgz", nil)
+	req.Host = "charts.jetstack.io"
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+
+	repo := &p.HelmRepos[0]
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.handleHelmChartRepoTLSRequest(serverConn, req, "charts.jetstack.io", "10.0.0.1", nil, repo, time.Now())
+		serverConn.Close()
+	}()
+
+	resp, err := http.ReadResponse(bufio.NewReader(clientConn), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+	<-done
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("chart from approved repo should return 200, got %d", resp.StatusCode)
 	}
 }
 
@@ -1164,12 +1260,41 @@ func TestProxy_HelmChart_LearningMode_CertManager(t *testing.T) {
 	pending := p.HelmChartApprovals.ListPending()
 	found := false
 	for _, a := range pending {
-		if a.Host == "helm:cert-manager" {
+		if a.Host == "helm:charts.jetstack.io/cert-manager" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Error("learning mode: expected pending helm chart approval for helm:cert-manager")
+		t.Error("learning mode: expected pending helm chart approval for helm:charts.jetstack.io/cert-manager")
+	}
+}
+
+func TestMatchHelmRef(t *testing.T) {
+	tests := []struct {
+		pattern string
+		ref     string
+		want    bool
+	}{
+		// Exact match.
+		{"helm:charts.jetstack.io/cert-manager", "helm:charts.jetstack.io/cert-manager", true},
+		{"helm:charts.jetstack.io", "helm:charts.jetstack.io", true},
+		// Wildcard.
+		{"helm:charts.jetstack.io/*", "helm:charts.jetstack.io/cert-manager", true},
+		{"helm:charts.jetstack.io/*", "helm:charts.jetstack.io/nginx", true},
+		{"helm:charts.jetstack.io/*", "helm:charts.bitnami.com/nginx", false},
+		// Repo-level covers charts.
+		{"helm:charts.jetstack.io", "helm:charts.jetstack.io/cert-manager", true},
+		{"helm:charts.jetstack.io", "helm:charts.bitnami.com/nginx", false},
+		// Chart doesn't cover repo.
+		{"helm:charts.jetstack.io/cert-manager", "helm:charts.jetstack.io", false},
+		// No match.
+		{"helm:charts.jetstack.io/cert-manager", "helm:charts.jetstack.io/nginx", false},
+	}
+	for _, tt := range tests {
+		got := matchHelmRef(tt.pattern, tt.ref)
+		if got != tt.want {
+			t.Errorf("matchHelmRef(%q, %q) = %v, want %v", tt.pattern, tt.ref, got, tt.want)
+		}
 	}
 }

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1095,11 +1095,11 @@ async function loadHelmCharts() {
     currentHelmCharts = items;
     currentFilteredHelmCharts = items;
     currentCategories = meta.categories || [];
-    populateSelect('filter-helm-chart-category', currentCategories.map(c => ({ value: c, label: c })), 'All categories');
+    populateSelect('filter-helm_chart-category', currentCategories.map(c => ({ value: c, label: c })), 'All categories');
     const skillOpts = (meta.skill_ids || []).map(id => ({ value: id, label: skillNameByID(id) }));
     skillOpts.sort((a, b) => a.label.localeCompare(b.label));
-    populateSelect('filter-helm-chart-skill', skillOpts, 'All skills');
-    populateSelect('filter-helm-chart-ip', (meta.source_ips || []).map(ip => ({ value: ip, label: ip })), 'All source IPs');
+    populateSelect('filter-helm_chart-skill', skillOpts, 'All skills');
+    populateSelect('filter-helm_chart-ip', (meta.source_ips || []).map(ip => ({ value: ip, label: ip })), 'All source IPs');
     const tbody = document.getElementById('helm-charts-tbody');
     const rows = [];
     if (items.length === 0) {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -174,16 +174,16 @@
           <button class="btn btn-primary" onclick="showAddHelmChartRule()">+ Add Helm Chart Rule</button>
         </div>
         <div class="filter-bar">
-          <select id="filter-helm-chart-category" onchange="onFilterChange('helm_chart')">
+          <select id="filter-helm_chart-category" onchange="onFilterChange('helm_chart')">
             <option value="">All categories</option>
           </select>
-          <select id="filter-helm-chart-skill" onchange="onFilterChange('helm_chart')">
+          <select id="filter-helm_chart-skill" onchange="onFilterChange('helm_chart')">
             <option value="">All skills</option>
           </select>
-          <select id="filter-helm-chart-ip" onchange="onFilterChange('helm_chart')">
+          <select id="filter-helm_chart-ip" onchange="onFilterChange('helm_chart')">
             <option value="">All source IPs</option>
           </select>
-          <select id="filter-helm-chart-status" onchange="onFilterChange('helm_chart')">
+          <select id="filter-helm_chart-status" onchange="onFilterChange('helm_chart')">
             <option value="">All statuses</option>
             <option value="approved">Approved</option>
             <option value="denied">Denied</option>


### PR DESCRIPTION
## Summary
This PR refactors Helm chart approval logic to support repo-level approvals and wildcard patterns. Previously, only individual charts could be approved. Now, approving a repository implicitly covers all charts from that repo, and wildcard patterns ("helm:host/*") are supported for more flexible approval management.

## Key Changes

- **Repo-level approval references**: Changed from chart-only refs like "helm:cert-manager" to hierarchical refs:
  - "helm:charts.jetstack.io" for repo-level (metadata) requests
  - "helm:charts.jetstack.io/cert-manager" for specific charts
  
- **New matching logic**: Implemented `matchHelmRef()` function supporting:
  - Exact matches: "helm:host/chart" == "helm:host/chart"
  - Wildcard patterns: "helm:host/*" matches any chart from that host
  - Repo-level coverage: "helm:host" implicitly approves "helm:host/chart"

- **Approval workflow changes**:
  - Metadata requests (index.yaml) now create pending repo-level approvals instead of being auto-approved
  - Added `checkHelmApprovalFastPath()` for efficient approval checking with pattern matching
  - Updated `checkHelmChartApproval()` to use the new matching logic across all three approval levels (global, VM-specific, skill-specific)

- **Test coverage**: 
  - Updated existing tests to use new ref format
  - Added `TestProxy_HelmChart_IndexYaml_CreatesRepoEntry()` to verify pending repo entries
  - Renamed `TestProxy_HelmChart_IndexYaml_AutoApproved()` to `TestProxy_HelmChart_IndexYaml_ApprovedRepo()`
  - Added `TestProxy_HelmChart_RepoApproval_CoversCharts()` to verify repo approval covers individual charts
  - Added `TestMatchHelmRef()` with comprehensive pattern matching test cases

- **UI fixes**: Corrected filter element IDs in HTML and JavaScript from "filter-helm-chart-*" to "filter-helm_chart-*" for consistency

- **Config updates**: Added Rancher Helm repository to the default configuration

## Implementation Details

The approval hierarchy now works as follows:
1. Check for exact chart approval: "helm:host/chart"
2. Check for wildcard approval: "helm:host/*"
3. Check for repo-level approval: "helm:host" (implicitly covers all charts)

This allows administrators to approve entire repositories at once while still supporting granular per-chart approvals when needed.

https://claude.ai/code/session_011PewXT9gZuYr275NgYv5Mo