### PR TITLE
Simplify apk update command invocation in Alpine build

### DIFF
--- a/internal/image/build.go
+++ b/internal/image/build.go
@@ -143,7 +143,7 @@ func (m *Manager) buildAlpine(img *DiskImage, rootfsPath, serverIP string, setti
 	basePkgs := []string{"linux-virt", "syslinux", "e2fsprogs", "openrc", "alpine-base", "ca-certificates", "openssh", "git"}
 	allPkgs := append(basePkgs, img.Packages...)
 
-	if err := runChroot(rootfsDir, "apk", append([]string{"update"})...); err != nil {
+	if err := runChroot(rootfsDir, "apk", "update"); err != nil {
 		return fmt.Errorf("apk update: %w", err)
 	}
 	if err := runChroot(rootfsDir, "apk", append([]string{"add"}, allPkgs...)...); err != nil {


### PR DESCRIPTION
## Summary
Simplified the `apk update` command invocation in the Alpine image build process by removing unnecessary slice allocation and unpacking.

## Changes
- Replaced `append([]string{"update"})...` with a direct string argument `"update"` when calling `runChroot()`
- This eliminates redundant slice creation and unpacking for a single-argument command

## Details
The original code created an empty slice, appended "update" to it, and then unpacked it with the spread operator. The simplified version passes "update" directly as a string argument, which is functionally equivalent but more concise and efficient. This change maintains the same behavior while improving code clarity.

https://claude.ai/code/session_01KfcfX1YpozZZaZhaJjvEu4