### PR TITLE
Add build cancellation support for disk image builds

### DIFF
--- a/cmd/firewall4ai/main.go
+++ b/cmd/firewall4ai/main.go
@@ -281,14 +281,24 @@ func main() {
 			d.DiskImages = imageMgr.ExportImages()
 		})
 
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		imageMgr.SetActiveBuildCancel(img.ID, version, cancel)
+		defer imageMgr.SetActiveBuildCancel(img.ID, version, nil)
+
 		bl := image.NewBuildLogger()
 		imageMgr.SetActiveBuildLog(img.ID, version, bl)
 		keyboard, tz := apiHandler.GetVMSettings()
 		gitCfg := config.GetGitConfig()
 		buildSettings := image.BuildSettings{Keyboard: keyboard, Timezone: tz, GitUsername: gitCfg.Username, GitEmail: gitCfg.Email}
-		if err := imageMgr.BuildImage(img, version, serverIP.String(), buildSettings, bl); err != nil {
-			log.Printf("Failed to build image %s v%d: %v", img.Name, version, err)
-			imageMgr.SetVersionStatus(img.ID, version, image.BuildStatusError, err.Error())
+		if err := imageMgr.BuildImage(ctx, img, version, serverIP.String(), buildSettings, bl); err != nil {
+			if err == image.ErrBuildCanceled {
+				log.Printf("Build canceled for image %s v%d", img.Name, version)
+				imageMgr.SetVersionStatus(img.ID, version, image.BuildStatusCanceled, "build canceled by user")
+			} else {
+				log.Printf("Failed to build image %s v%d: %v", img.Name, version, err)
+				imageMgr.SetVersionStatus(img.ID, version, image.BuildStatusError, err.Error())
+			}
 		} else {
 			imageMgr.SetVersionStatus(img.ID, version, image.BuildStatusReady, "")
 		}

--- a/internal/api/imagemgmt.go
+++ b/internal/api/imagemgmt.go
@@ -22,6 +22,7 @@ func (h *Handler) RegisterImageMgmtRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/disk-images/build", h.buildDiskImage)
 	mux.HandleFunc("DELETE /api/disk-images/version", h.deleteDiskImageVersion)
 	mux.HandleFunc("GET /api/disk-images/build-log", h.getDiskImageBuildLog)
+	mux.HandleFunc("POST /api/disk-images/cancel-build", h.cancelDiskImageBuild)
 	mux.HandleFunc("GET /api/rtk-releases", h.getRtkReleases)
 }
 
@@ -270,6 +271,32 @@ func (h *Handler) getDiskImageBuildLog(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{
 		"log": logContent,
 	})
+}
+
+func (h *Handler) cancelDiskImageBuild(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ID      string `json:"id"`
+		Version int    `json:"version"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.ID == "" || req.Version == 0 {
+		http.Error(w, "id and version are required", http.StatusBadRequest)
+		return
+	}
+
+	if _, ok := h.ImageManager.Get(req.ID); !ok {
+		http.Error(w, fmt.Sprintf("image %q not found", req.ID), http.StatusNotFound)
+		return
+	}
+
+	if h.ImageManager.CancelBuild(req.ID, req.Version) {
+		writeJSON(w, http.StatusOK, map[string]string{"result": "build canceling"})
+	} else {
+		http.Error(w, "no active build found for this version", http.StatusNotFound)
+	}
 }
 
 // getRtkReleases fetches available rtk release versions from GitHub.

--- a/internal/image/build.go
+++ b/internal/image/build.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -47,15 +48,22 @@ type BuildSettings struct {
 	GitEmail    string // git user.email
 }
 
+// ErrBuildCanceled is returned when a build is canceled by the user.
+var ErrBuildCanceled = fmt.Errorf("build canceled")
+
 // BuildImage builds a new version of a disk image by creating a rootfs tarball.
 // This runs as a long-running operation and should be called in a goroutine.
 // The serverIP is the firewall's agent-facing IP (e.g., 10.255.255.1).
 // If bl is non-nil, build output is captured to it.
-func (m *Manager) BuildImage(img *DiskImage, version int, serverIP string, settings BuildSettings, bl *BuildLogger) error {
+// The context can be used to cancel the build.
+func (m *Manager) BuildImage(ctx context.Context, img *DiskImage, version int, serverIP string, settings BuildSettings, bl *BuildLogger) error {
 	if bl != nil {
 		setBuildLogger(bl)
 		defer setBuildLogger(nil)
 	}
+	setBuildContext(ctx)
+	defer setBuildContext(nil)
+
 	versionDir := m.VersionDir(img.ID, version)
 	if err := os.MkdirAll(versionDir, 0o755); err != nil {
 		return fmt.Errorf("create version dir: %w", err)
@@ -63,16 +71,27 @@ func (m *Manager) BuildImage(img *DiskImage, version int, serverIP string, setti
 
 	rootfsPath := filepath.Join(versionDir, "rootfs.tar.gz")
 
+	var err error
 	switch img.OS {
 	case agent.OSAlpine:
-		return m.buildAlpine(img, rootfsPath, serverIP, settings, bl)
+		err = m.buildAlpine(img, rootfsPath, serverIP, settings, bl)
 	case agent.OSDebian:
-		return m.buildDebian(img, rootfsPath, serverIP, "debian", settings, bl)
+		err = m.buildDebian(img, rootfsPath, serverIP, "debian", settings, bl)
 	case agent.OSUbuntu:
-		return m.buildDebian(img, rootfsPath, serverIP, "ubuntu", settings, bl)
+		err = m.buildDebian(img, rootfsPath, serverIP, "ubuntu", settings, bl)
 	default:
 		return fmt.Errorf("unsupported OS type: %s", img.OS)
 	}
+
+	// If the build failed or was canceled, clean up any partial tarball.
+	if err != nil {
+		os.Remove(rootfsPath)
+		os.Remove(rootfsPath + ".tmp")
+		if ctx.Err() != nil {
+			return ErrBuildCanceled
+		}
+	}
+	return err
 }
 
 // buildAlpine builds an Alpine Linux rootfs tarball.
@@ -746,6 +765,12 @@ var activeBuildLogger struct {
 	bl *BuildLogger
 }
 
+// activeBuildCtx holds the current build context for cancellation support.
+var activeBuildCtx struct {
+	mu  sync.Mutex
+	ctx context.Context
+}
+
 func setBuildLogger(bl *BuildLogger) {
 	activeBuildLogger.mu.Lock()
 	activeBuildLogger.bl = bl
@@ -756,6 +781,21 @@ func getBuildLogger() *BuildLogger {
 	activeBuildLogger.mu.Lock()
 	defer activeBuildLogger.mu.Unlock()
 	return activeBuildLogger.bl
+}
+
+func setBuildContext(ctx context.Context) {
+	activeBuildCtx.mu.Lock()
+	activeBuildCtx.ctx = ctx
+	activeBuildCtx.mu.Unlock()
+}
+
+func getBuildContext() context.Context {
+	activeBuildCtx.mu.Lock()
+	defer activeBuildCtx.mu.Unlock()
+	if activeBuildCtx.ctx != nil {
+		return activeBuildCtx.ctx
+	}
+	return context.Background()
 }
 
 func cmdOutput() (io.Writer, io.Writer) {
@@ -778,25 +818,28 @@ func buildLog(format string, args ...interface{}) {
 }
 
 func run(name string, args ...string) error {
-	cmd := exec.Command(name, args...)
+	ctx := getBuildContext()
+	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Stdout, cmd.Stderr = cmdOutput()
 	return cmd.Run()
 }
 
 // runChroot runs a command inside a chroot.
 func runChroot(rootfs, name string, args ...string) error {
+	ctx := getBuildContext()
 	chrootArgs := append([]string{rootfs, name}, args...)
-	cmd := exec.Command("chroot", chrootArgs...)
+	cmd := exec.CommandContext(ctx, "chroot", chrootArgs...)
 	cmd.Stdout, cmd.Stderr = cmdOutput()
 	return cmd.Run()
 }
 
 // runChrootEnv runs a command inside a chroot with extra environment variables.
 func runChrootEnv(rootfs string, env []string, name string, args ...string) error {
+	ctx := getBuildContext()
 	// Use env to set variables, then chroot.
 	envArgs := append(env, "chroot", rootfs, name)
 	envArgs = append(envArgs, args...)
-	cmd := exec.Command("env", envArgs...)
+	cmd := exec.CommandContext(ctx, "env", envArgs...)
 	cmd.Stdout, cmd.Stderr = cmdOutput()
 	return cmd.Run()
 }

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -17,10 +17,11 @@ import (
 type BuildStatus string
 
 const (
-	BuildStatusPending  BuildStatus = "pending"
-	BuildStatusBuilding BuildStatus = "building"
-	BuildStatusReady    BuildStatus = "ready"
-	BuildStatusError    BuildStatus = "error"
+	BuildStatusPending   BuildStatus = "pending"
+	BuildStatusBuilding  BuildStatus = "building"
+	BuildStatusReady     BuildStatus = "ready"
+	BuildStatusError     BuildStatus = "error"
+	BuildStatusCanceled  BuildStatus = "canceled"
 )
 
 // ImageVersion represents a built version of a disk image.
@@ -97,16 +98,44 @@ type Manager struct {
 	images       map[string]*DiskImage
 	dataDir      string
 	activeLogsMu sync.RWMutex
-	activeLogs   map[string]*BuildLogger // key: "imageID/version"
+	activeLogs   map[string]*BuildLogger  // key: "imageID/version"
+	cancelsMu    sync.Mutex
+	activeCancels map[string]func()        // key: "imageID/version" -> cancel func
 }
 
 // NewManager creates a new image manager.
 func NewManager(dataDir string) *Manager {
 	return &Manager{
-		images:     make(map[string]*DiskImage),
-		dataDir:    dataDir,
-		activeLogs: make(map[string]*BuildLogger),
+		images:        make(map[string]*DiskImage),
+		dataDir:       dataDir,
+		activeLogs:    make(map[string]*BuildLogger),
+		activeCancels: make(map[string]func()),
 	}
+}
+
+// SetActiveBuildCancel registers a cancel function for an in-progress build.
+func (m *Manager) SetActiveBuildCancel(imageID string, version int, cancel func()) {
+	m.cancelsMu.Lock()
+	defer m.cancelsMu.Unlock()
+	key := fmt.Sprintf("%s/%d", imageID, version)
+	if cancel != nil {
+		m.activeCancels[key] = cancel
+	} else {
+		delete(m.activeCancels, key)
+	}
+}
+
+// CancelBuild cancels an in-progress build. Returns true if a build was canceled.
+func (m *Manager) CancelBuild(imageID string, version int) bool {
+	m.cancelsMu.Lock()
+	key := fmt.Sprintf("%s/%d", imageID, version)
+	cancel, ok := m.activeCancels[key]
+	m.cancelsMu.Unlock()
+	if ok && cancel != nil {
+		cancel()
+		return true
+	}
+	return false
 }
 
 // SetActiveBuildLog registers a live build logger for an in-progress build.

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -2948,6 +2948,7 @@ function imageVersionStatusClass(status) {
     case 'building': return 'pending';
     case 'pending': return 'pending';
     case 'error': return 'denied';
+    case 'canceled': return 'denied';
     default: return '';
   }
 }
@@ -3112,9 +3113,12 @@ async function showBuildLog(imageId, version, status) {
   document.getElementById('build-log-content').textContent = 'Loading...';
   document.getElementById('modal-build-log').classList.add('active');
 
-  // Hide delete button while build is active.
+  // Show cancel button and hide delete button while build is active.
+  const isActive = (status === 'building' || status === 'pending');
   const deleteBtn = document.getElementById('build-log-delete-btn');
-  deleteBtn.style.display = (status === 'building' || status === 'pending') ? 'none' : '';
+  const cancelBtn = document.getElementById('build-log-cancel-btn');
+  deleteBtn.style.display = isActive ? 'none' : '';
+  cancelBtn.style.display = isActive ? '' : 'none';
 
   await refreshBuildLog();
 
@@ -3141,6 +3145,7 @@ async function refreshBuildLog() {
       if (ver && ver.status !== 'building' && ver.status !== 'pending') {
         stopBuildLogRefresh();
         document.getElementById('build-log-delete-btn').style.display = '';
+        document.getElementById('build-log-cancel-btn').style.display = 'none';
         loadDiskImages();
       }
     }
@@ -3185,6 +3190,17 @@ async function deleteVersionFromLog() {
     loadDiskImages();
   } catch (e) {
     alert('Failed to delete version: ' + e.message);
+  }
+}
+
+async function cancelBuildFromLog() {
+  if (!buildLogImageId || buildLogVersion == null) return;
+  if (!confirm(`Cancel build v${buildLogVersion}?`)) return;
+  try {
+    await api('POST', '/api/disk-images/cancel-build', { id: buildLogImageId, version: buildLogVersion });
+    document.getElementById('build-log-cancel-btn').style.display = 'none';
+  } catch (e) {
+    alert('Failed to cancel build: ' + e.message);
   }
 }
 

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -1123,6 +1123,7 @@
       <pre id="build-log-content" style="background:var(--bg-secondary);padding:12px;border-radius:6px;max-height:60vh;overflow-y:auto;font-size:12px;white-space:pre-wrap;word-break:break-all"></pre>
       <div class="modal-actions">
         <button class="btn btn-outline" onclick="downloadBuildLog()">Download Log</button>
+        <button class="btn btn-danger" id="build-log-cancel-btn" onclick="cancelBuildFromLog()" style="display:none">Cancel Build</button>
         <button class="btn btn-danger" id="build-log-delete-btn" onclick="deleteVersionFromLog()">Delete Version</button>
         <button class="btn btn-outline" onclick="hideBuildLog()">Close</button>
       </div>


### PR DESCRIPTION
## Summary
This PR adds the ability to cancel in-progress disk image builds. Users can now request cancellation of a build through a new API endpoint, and the build process will clean up partial artifacts and report the cancellation status.

## Key Changes

- **Context-based cancellation**: Modified `BuildImage()` to accept a `context.Context` parameter, allowing builds to be canceled via context cancellation
- **Build context management**: Added `setBuildContext()` and `getBuildContext()` functions to track the active build context across command execution
- **Command cancellation**: Updated `run()`, `runChroot()`, and `runChrootEnv()` to use `exec.CommandContext()` for proper process cancellation
- **Cleanup on cancellation**: Added logic to remove partial tarball files (`rootfs.tar.gz` and `.tar.gz.tmp`) when a build is canceled or fails
- **New build status**: Added `BuildStatusCanceled` status to track canceled builds separately from errors
- **Cancel API endpoint**: Implemented `POST /api/disk-images/cancel-build` endpoint to trigger build cancellation
- **Manager-level cancellation**: Added `SetActiveBuildCancel()` and `CancelBuild()` methods to the image Manager to track and invoke cancel functions for active builds
- **UI updates**: Added cancel button to the build log modal that appears during active builds, with proper visibility toggling
- **Error handling**: Introduced `ErrBuildCanceled` error type to distinguish canceled builds from other failures

## Implementation Details

- Build cancellation is managed through Go's context package, which gracefully propagates cancellation signals to all spawned processes
- The cancel function is registered with the image manager before the build starts and cleaned up afterward
- When a build is canceled, the context error is checked to determine if cancellation (rather than another error) occurred
- The UI automatically hides the cancel button and shows the delete button once the build completes
- Build log refresh stops polling once the build reaches a terminal state (ready, error, or canceled)

https://claude.ai/code/session_01PGe4fswYBTDpN1rpjN7QFe