### PR TITLE
Refactor proxy initialization and improve goproxy logging integration

### DIFF
--- a/cmd/firewall4ai/main.go
+++ b/cmd/firewall4ai/main.go
@@ -349,8 +349,7 @@ func main() {
 	}
 
 	// Setup proxy server with CA for MITM and registry awareness.
-	p := proxy.New(skills, approvals, creds, logger)
-	p.CA = ca
+	p := proxy.New(skills, approvals, creds, logger, ca)
 	p.ImageApprovals = imageApprovals
 	p.HelmChartApprovals = helmChartApprovals
 	p.PackageApprovals = packageApprovals

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -67,13 +67,30 @@ type Proxy struct {
 	goProxy *goproxy.ProxyHttpServer
 }
 
+// goproxyLogBridge adapts our proxylog.Logger to goproxy's Logger interface,
+// routing goproxy internal messages through our unified logging.
+type goproxyLogBridge struct {
+	logger *proxylog.Logger
+}
+
+func (b *goproxyLogBridge) Printf(format string, v ...any) {
+	msg := fmt.Sprintf(format, v...)
+	b.logger.Add(proxylog.Entry{
+		Method: "GOPROXY",
+		Status: "info",
+		Detail: msg,
+	})
+}
+
 // New creates a new Proxy with the given dependencies.
-func New(skills *auth.SkillStore, approvals *approval.Manager, creds *credentials.Manager, logger *proxylog.Logger) *Proxy {
+// The ca parameter is optional; when non-nil it enables TLS MITM inspection.
+func New(skills *auth.SkillStore, approvals *approval.Manager, creds *credentials.Manager, logger *proxylog.Logger, ca *certgen.CA) *Proxy {
 	p := &Proxy{
 		Skills:          skills,
 		Approvals:       approvals,
 		Credentials:     creds,
 		Logger:          logger,
+		CA:              ca,
 		ApprovalTimeout: approvalTimeout,
 		Transport: &http.Transport{
 			TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
@@ -86,6 +103,7 @@ func New(skills *auth.SkillStore, approvals *approval.Manager, creds *credential
 
 	gp := goproxy.NewProxyHttpServer()
 	gp.Verbose = false
+	gp.Logger = &goproxyLogBridge{logger: logger}
 
 	// CONNECT handler: decide MITM vs blind tunnel vs reject.
 	gp.OnRequest().HandleConnect(goproxy.FuncHttpsHandler(p.handleConnectDecision))
@@ -219,21 +237,10 @@ func writeErrorResponseConn(conn net.Conn, status approval.Status, resource stri
 	resp.Write(conn)
 }
 
-// errorResponse creates an *http.Response with the given status code and plain text message.
+// errorResponse creates an *http.Response using goproxy.NewResponse to keep
+// goproxy's internal state consistent when used within OnRequest handlers.
 func errorResponse(req *http.Request, code int, msg string) *http.Response {
-	body := msg + "\n"
-	resp := &http.Response{
-		StatusCode:    code,
-		Status:        fmt.Sprintf("%d %s", code, http.StatusText(code)),
-		ProtoMajor:    1,
-		ProtoMinor:    1,
-		Header:        make(http.Header),
-		Body:          io.NopCloser(strings.NewReader(body)),
-		ContentLength: int64(len(body)),
-		Request:       req,
-	}
-	resp.Header.Set("Content-Type", "text/plain; charset=utf-8")
-	return resp
+	return goproxy.NewResponse(req, "text/plain; charset=utf-8", code, msg+"\n")
 }
 
 // --- Forwarding helpers (for transparent TLS only) ---
@@ -245,15 +252,10 @@ func errorResponse(req *http.Request, code int, msg string) *http.Response {
 // stays open (e.g. helm repo add with ~600KB index responses).
 func forwardTLS(conn net.Conn, resp *http.Response) {
 	if resp.ContentLength < 0 && resp.Body != nil {
-		body, err := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		if err != nil {
-			resp.Body = io.NopCloser(bytes.NewReader(body))
-			resp.ContentLength = int64(len(body))
-		} else {
-			resp.Body = io.NopCloser(bytes.NewReader(body))
-			resp.ContentLength = int64(len(body))
-		}
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		resp.ContentLength = int64(len(body))
 		resp.TransferEncoding = nil
 	}
 	resp.Write(conn)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -33,19 +33,23 @@ func setupProxy(t *testing.T) (*Proxy, *auth.SkillStore, *approval.Manager) {
 	approvals := approval.NewManager()
 	creds := credentials.NewManager()
 	logger := proxylog.NewLogger(100)
-	p := New(skills, approvals, creds, logger)
+	p := New(skills, approvals, creds, logger, nil)
 	p.ApprovalTimeout = 50 * time.Millisecond // short timeout for tests
 	return p, skills, approvals
 }
 
 func setupProxyWithCA(t *testing.T) (*Proxy, *auth.SkillStore, *approval.Manager, *certgen.CA) {
 	t.Helper()
-	p, skills, approvals := setupProxy(t)
+	skills := auth.NewSkillStore()
+	approvals := approval.NewManager()
+	creds := credentials.NewManager()
+	logger := proxylog.NewLogger(100)
 	ca, err := certgen.LoadOrGenerateCA(t.TempDir())
 	if err != nil {
 		t.Fatalf("LoadOrGenerateCA() error: %v", err)
 	}
-	p.CA = ca
+	p := New(skills, approvals, creds, logger, ca)
+	p.ApprovalTimeout = 50 * time.Millisecond // short timeout for tests
 	return p, skills, approvals, ca
 }
 


### PR DESCRIPTION
## Summary
This PR refactors the proxy initialization to accept the CA certificate authority as a constructor parameter, improves goproxy's logging integration through a custom log bridge, and simplifies error response handling.

## Key Changes

- **Constructor refactoring**: Modified `proxy.New()` to accept an optional `*certgen.CA` parameter instead of requiring post-construction assignment. This makes the CA a first-class dependency and improves API clarity.

- **Logging integration**: Introduced `goproxyLogBridge` adapter that routes goproxy's internal log messages through the unified `proxylog.Logger`, ensuring all proxy activity is captured in a consistent format with method "GOPROXY" and status "info".

- **Error response simplification**: Replaced manual `http.Response` construction in `errorResponse()` with `goproxy.NewResponse()` to maintain goproxy's internal state consistency when used within OnRequest handlers.

- **Code cleanup**: 
  - Simplified `forwardTLS()` by removing redundant error handling branches (both paths performed identical operations)
  - Updated test helpers to pass CA through constructor rather than post-construction assignment

## Implementation Details

- The CA parameter is optional (can be `nil`), allowing the proxy to function without MITM inspection when needed
- The `goproxyLogBridge` formats goproxy messages using `fmt.Sprintf` before logging them as structured entries
- All call sites updated to use the new constructor signature (test setup helpers and main.go)

https://claude.ai/code/session_01251ehkgiKsArwdhpbG8g2J