### PR TITLE
Remove token-based authentication and pre-approved hosts

### DIFF
--- a/internal/api/api_skills.go
+++ b/internal/api/api_skills.go
@@ -83,13 +83,12 @@ func (h *Handler) updateSkill(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("skill %q not found", req.ID), http.StatusNotFound)
 		return
 	}
-	// Preserve token and allowed hosts (internal fields).
+	// Preserve token (internal field).
 	updated := auth.Skill{
 		ID:          existing.ID,
 		Name:        req.Name,
 		Description: req.Description,
 		Token:       existing.Token,
-		AllowedHost: existing.AllowedHost,
 		Active:      req.Active,
 	}
 	if err := h.Skills.UpdateSkill(updated); err != nil {

--- a/internal/approval/approval.go
+++ b/internal/approval/approval.go
@@ -108,30 +108,6 @@ func (m *Manager) CheckExisting(host, skillID, sourceIP, pathPrefix string) (Sta
 	return a.Status, true
 }
 
-// CheckExistingWithWildcards is like CheckExisting but also matches wildcard
-// host patterns (e.g., *.example.com matches api.example.com).
-// It checks exact match first, then scans for wildcard patterns.
-// This method does NOT consider path prefixes — use CheckExistingWithPath
-// for path-aware checks.
-func (m *Manager) CheckExistingWithWildcards(host, skillID, sourceIP string) (Status, bool) {
-	// Try exact match first (fast path).
-	if status, ok := m.CheckExisting(host, skillID, sourceIP, ""); ok {
-		return status, true
-	}
-	// Scan for wildcard patterns (host-only, no path prefix).
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	for _, a := range m.approvals {
-		if a.SkillID != skillID || a.SourceIP != sourceIP || a.PathPrefix != "" {
-			continue
-		}
-		if a.Host != host && MatchHost(a.Host, host) {
-			return a.Status, true
-		}
-	}
-	return "", false
-}
-
 // CheckExistingWithPath checks for an approval matching the host and path.
 // It considers both wildcard host patterns and path prefix matching.
 // An approval with empty PathPrefix covers all paths. An approval with
@@ -401,7 +377,7 @@ func (m *Manager) LoadApprovals(approvals []HostApproval) {
 	}
 }
 
-// CheckExistingWithMatcher is like CheckExistingWithWildcards but uses a
+// CheckExistingWithMatcher is like CheckExisting but uses a
 // caller-provided match function instead of MatchHost. This allows the
 // registry package to use image-reference-specific pattern matching.
 func (m *Manager) CheckExistingWithMatcher(host, skillID, sourceIP string, matcher func(pattern, host string) bool) (Status, bool) {

--- a/internal/approval/approval_test.go
+++ b/internal/approval/approval_test.go
@@ -259,14 +259,14 @@ func TestManager_WildcardApproval(t *testing.T) {
 		t.Error("exact match should not exist for wildcard rule")
 	}
 
-	// Wildcard-aware check should match.
-	status, exists := m.CheckExistingWithWildcards("api.example.com", "", "")
+	// Path-aware check should match wildcards.
+	status, exists := m.CheckExistingWithPath("api.example.com", "/any", "", "")
 	if !exists || status != StatusApproved {
 		t.Errorf("expected wildcard match approved, got %s (exists=%v)", status, exists)
 	}
 
 	// Non-matching host should not match.
-	_, exists = m.CheckExistingWithWildcards("other.com", "", "")
+	_, exists = m.CheckExistingWithPath("other.com", "/any", "", "")
 	if exists {
 		t.Error("non-matching host should not match wildcard")
 	}
@@ -279,13 +279,13 @@ func TestManager_WildcardVMApproval(t *testing.T) {
 	m.Decide("*.github.com", "", "10.255.255.10", "", StatusApproved, "vm wildcard")
 
 	// Should match for that VM.
-	status, exists := m.CheckExistingWithWildcards("api.github.com", "", "10.255.255.10")
+	status, exists := m.CheckExistingWithPath("api.github.com", "/any", "", "10.255.255.10")
 	if !exists || status != StatusApproved {
 		t.Errorf("expected VM wildcard match, got %s (exists=%v)", status, exists)
 	}
 
 	// Should not match for different VM.
-	_, exists = m.CheckExistingWithWildcards("api.github.com", "", "10.255.255.11")
+	_, exists = m.CheckExistingWithPath("api.github.com", "/any", "", "10.255.255.11")
 	if exists {
 		t.Error("wildcard should not match different VM")
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,36 +1,32 @@
-// Package auth handles AI agent skill-token authentication and rulesets.
+// Package auth handles AI agent skill management and ID generation.
 package auth
 
 import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"strings"
 	"sync"
 )
 
-// Skill represents an AI agent skill with its own token and rules.
+// Skill represents an AI agent skill.
 type Skill struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	Token       string   `json:"token"`
-	AllowedHost []string `json:"allowed_hosts"` // hosts pre-approved for this skill
-	Active      bool     `json:"active"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Token       string `json:"token"`
+	Active      bool   `json:"active"`
 }
 
-// SkillStore manages skills and their tokens.
+// SkillStore manages skills.
 type SkillStore struct {
-	mu     sync.RWMutex
-	skills map[string]*Skill // keyed by token
-	byID   map[string]*Skill // keyed by ID
+	mu   sync.RWMutex
+	byID map[string]*Skill // keyed by ID
 }
 
 // NewSkillStore creates a new empty skill store.
 func NewSkillStore() *SkillStore {
 	return &SkillStore{
-		skills: make(map[string]*Skill),
-		byID:   make(map[string]*Skill),
+		byID: make(map[string]*Skill),
 	}
 }
 
@@ -49,14 +45,13 @@ func GenerateToken() (string, error) {
 	return GenerateGUID(), nil
 }
 
-// AddSkill registers a new skill with its token.
+// AddSkill registers a new skill.
 func (s *SkillStore) AddSkill(skill Skill) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, exists := s.byID[skill.ID]; exists {
 		return fmt.Errorf("skill %q already exists", skill.ID)
 	}
-	s.skills[skill.Token] = &skill
 	s.byID[skill.ID] = &skill
 	return nil
 }
@@ -81,11 +76,7 @@ func (s *SkillStore) UpdateSkill(skill Skill) error {
 	if !ok {
 		return fmt.Errorf("skill %q not found", skill.ID)
 	}
-	// Remove old token mapping.
-	delete(s.skills, existing.Token)
-	// Update.
 	*existing = skill
-	s.skills[skill.Token] = existing
 	return nil
 }
 
@@ -93,43 +84,11 @@ func (s *SkillStore) UpdateSkill(skill Skill) error {
 func (s *SkillStore) DeleteSkill(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	skill, ok := s.byID[id]
-	if !ok {
+	if _, ok := s.byID[id]; !ok {
 		return fmt.Errorf("skill %q not found", id)
 	}
-	delete(s.skills, skill.Token)
 	delete(s.byID, id)
 	return nil
-}
-
-// Authenticate checks a token and returns the associated skill.
-func (s *SkillStore) Authenticate(token string) (*Skill, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	skill, ok := s.skills[token]
-	if !ok || !skill.Active {
-		return nil, false
-	}
-	return skill, true
-}
-
-// IsHostPreApproved checks if a host is in the skill's allowed list.
-func (s *SkillStore) IsHostPreApproved(token, host string) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	skill, ok := s.skills[token]
-	if !ok {
-		return false
-	}
-	for _, h := range skill.AllowedHost {
-		if h == host || h == "*" {
-			return true
-		}
-		if strings.HasPrefix(h, "*.") && strings.HasSuffix(host, h[1:]) {
-			return true
-		}
-	}
-	return false
 }
 
 // ListSkills returns all skills.
@@ -147,11 +106,9 @@ func (s *SkillStore) ListSkills() []Skill {
 func (s *SkillStore) LoadSkills(skills []Skill) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.skills = make(map[string]*Skill)
 	s.byID = make(map[string]*Skill)
 	for i := range skills {
 		sk := &skills[i]
-		s.skills[sk.Token] = sk
 		s.byID[sk.ID] = sk
 	}
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -36,7 +36,7 @@ func TestGenerateGUID(t *testing.T) {
 	}
 }
 
-func TestSkillStore_AddAndAuthenticate(t *testing.T) {
+func TestSkillStore_AddAndGet(t *testing.T) {
 	s := NewSkillStore()
 
 	skill := Skill{ID: "test-skill", Name: "Test", Token: "tok-123", Active: true}
@@ -49,30 +49,19 @@ func TestSkillStore_AddAndAuthenticate(t *testing.T) {
 		t.Error("expected error adding duplicate skill")
 	}
 
-	// Authenticate with valid token.
-	got, ok := s.Authenticate("tok-123")
+	// Get by ID.
+	got, ok := s.GetSkill("test-skill")
 	if !ok {
-		t.Fatal("Authenticate() returned false for valid token")
+		t.Fatal("GetSkill() returned false for existing skill")
 	}
 	if got.ID != "test-skill" {
 		t.Errorf("expected skill ID %q, got %q", "test-skill", got.ID)
 	}
 
-	// Invalid token.
-	_, ok = s.Authenticate("bad-token")
+	// Non-existent skill.
+	_, ok = s.GetSkill("nonexistent")
 	if ok {
-		t.Error("Authenticate() should return false for invalid token")
-	}
-}
-
-func TestSkillStore_InactiveSkill(t *testing.T) {
-	s := NewSkillStore()
-	skill := Skill{ID: "inactive", Name: "Inactive", Token: "tok-inactive", Active: false}
-	s.AddSkill(skill)
-
-	_, ok := s.Authenticate("tok-inactive")
-	if ok {
-		t.Error("Authenticate() should return false for inactive skill")
+		t.Error("GetSkill() should return false for non-existent skill")
 	}
 }
 
@@ -85,19 +74,15 @@ func TestSkillStore_UpdateSkill(t *testing.T) {
 		t.Fatalf("UpdateSkill() error: %v", err)
 	}
 
-	// Old token should not work.
-	_, ok := s.Authenticate("tok-1")
-	if ok {
-		t.Error("old token should not authenticate after update")
-	}
-
-	// New token should work.
-	got, ok := s.Authenticate("tok-2")
+	got, ok := s.GetSkill("s1")
 	if !ok {
-		t.Fatal("new token should authenticate after update")
+		t.Fatal("GetSkill should find updated skill")
 	}
 	if got.Name != "Updated" {
 		t.Errorf("expected name %q, got %q", "Updated", got.Name)
+	}
+	if got.Token != "tok-2" {
+		t.Errorf("expected token %q, got %q", "tok-2", got.Token)
 	}
 
 	// Update non-existent.
@@ -114,31 +99,13 @@ func TestSkillStore_DeleteSkill(t *testing.T) {
 		t.Fatalf("DeleteSkill() error: %v", err)
 	}
 
-	_, ok := s.Authenticate("tok-1")
+	_, ok := s.GetSkill("s1")
 	if ok {
-		t.Error("deleted skill should not authenticate")
+		t.Error("deleted skill should not be found")
 	}
 
 	if err := s.DeleteSkill("s1"); err == nil {
 		t.Error("expected error deleting non-existent skill")
-	}
-}
-
-func TestSkillStore_IsHostPreApproved(t *testing.T) {
-	s := NewSkillStore()
-	s.AddSkill(Skill{
-		ID: "s1", Token: "tok-1", Active: true,
-		AllowedHost: []string{"api.example.com", "*"},
-	})
-
-	if !s.IsHostPreApproved("tok-1", "api.example.com") {
-		t.Error("expected api.example.com to be pre-approved")
-	}
-	if !s.IsHostPreApproved("tok-1", "anything.com") {
-		t.Error("expected wildcard * to match any host")
-	}
-	if s.IsHostPreApproved("bad-token", "api.example.com") {
-		t.Error("bad token should not have pre-approved hosts")
 	}
 }
 
@@ -158,8 +125,8 @@ func TestSkillStore_ListAndLoad(t *testing.T) {
 	if len(s2.ListSkills()) != 2 {
 		t.Error("LoadSkills should restore all skills")
 	}
-	_, ok := s2.Authenticate("t-a")
+	_, ok := s2.GetSkill("a")
 	if !ok {
-		t.Error("loaded skill should authenticate")
+		t.Error("loaded skill should be found by ID")
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -28,8 +28,6 @@ import (
 
 const (
 	approvalTimeout = 15 * time.Minute
-	// AuthHeader is used by AI agents to provide their skill token.
-	AuthHeader = "X-Firewall4AI-Token"
 )
 
 // responseBodyWrapper restores the full original response body (prefix for logging
@@ -171,21 +169,6 @@ func getSkillID(skill *auth.Skill) string {
 		return ""
 	}
 	return skill.ID
-}
-
-// authenticateOptional extracts and validates the skill token.
-// Returns (nil, nil) if no token is provided (anonymous access).
-// Returns (nil, error) if an invalid token is provided.
-func (p *Proxy) authenticateOptional(r *http.Request) (*auth.Skill, error) {
-	token := r.Header.Get(AuthHeader)
-	if token == "" {
-		return nil, nil
-	}
-	skill, ok := p.Skills.Authenticate(token)
-	if !ok {
-		return nil, fmt.Errorf("invalid or inactive token")
-	}
-	return skill, nil
 }
 
 // getLoggingMode returns the logging mode for the request's host/path.

--- a/internal/proxy/proxy_approval.go
+++ b/internal/proxy/proxy_approval.go
@@ -18,11 +18,6 @@ import (
 // The path parameter enables fine-grained URL path approval; empty path
 // means host-level only (used for blind CONNECT tunnels).
 func (p *Proxy) checkApproval(host, path string, skill *auth.Skill, sourceIP string) approval.Status {
-	// Check pre-approved hosts for authenticated requests.
-	if skill != nil && p.Skills.IsHostPreApproved(skill.Token, host) {
-		return approval.StatusApproved
-	}
-
 	// 1. Check global approval (host+path approved/denied for all agents).
 	if globalStatus, exists := p.Approvals.CheckExistingWithPath(host, path, "", ""); exists && globalStatus != approval.StatusPending {
 		return globalStatus
@@ -63,11 +58,6 @@ func (p *Proxy) checkApproval(host, path string, skill *auth.Skill, sourceIP str
 // allowed if any path-specific approval exists, since per-request checks
 // will enforce path restrictions inside the tunnel.
 func (p *Proxy) checkHostApproval(host string, skill *auth.Skill, sourceIP string) approval.Status {
-	// Check pre-approved hosts.
-	if skill != nil && p.Skills.IsHostPreApproved(skill.Token, host) {
-		return approval.StatusApproved
-	}
-
 	// 1. Global: any approval for this host.
 	if status, exists := p.Approvals.CheckExistingForHost(host, "", ""); exists && status != approval.StatusPending {
 		return status

--- a/internal/proxy/proxy_connect.go
+++ b/internal/proxy/proxy_connect.go
@@ -32,18 +32,7 @@ func (p *Proxy) handleConnectDecision(host string, ctx *goproxy.ProxyCtx) (*gopr
 		p.OnActivity(sourceIP)
 	}
 
-	skill, err := p.authenticateOptional(ctx.Req)
-	if err != nil {
-		p.Logger.Add(proxylog.Entry{
-			Method: "CONNECT",
-			Host:   h,
-			Status: "denied",
-			Detail: "auth failed: " + err.Error(),
-		})
-		ctx.Resp = errorResponse(ctx.Req, http.StatusProxyAuthRequired,
-			"Proxy authentication failed: "+err.Error())
-		return goproxy.RejectConnect, host
-	}
+	var skill *auth.Skill // Agents are identified by IP, not by token.
 
 	// For CONNECT with MITM, auto-approve hosts that belong to configured
 	// infrastructure (registries, Helm repos, package repos, code libraries)
@@ -202,8 +191,7 @@ func (p *Proxy) handleMITM(clientConn net.Conn, host, targetAddr string, skill *
 		req.URL.Host = upstreamAddr
 		req.Host = host
 
-		// Process the request using the skill from the CONNECT auth.
-		resp, _ := p.processRequest(req, sourceIP, skill)
+		resp, _ := p.processRequest(req, sourceIP)
 
 		// Write response to the TLS connection.
 		forwardTLS(tlsClientConn, resp)

--- a/internal/proxy/proxy_connect_test.go
+++ b/internal/proxy/proxy_connect_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/olljanat-ai/firewall4ai/internal/auth"
 	"github.com/olljanat-ai/firewall4ai/internal/credentials"
 )
 
@@ -103,20 +102,19 @@ func TestProxy_CONNECT_NoAuth_Anonymous(t *testing.T) {
 	status, conn := connectViaProxy(t, proxyAddr, "example.com:443", nil)
 	defer conn.Close()
 
-	// Without token, CONNECT is anonymous. No approval -> timeout -> 407.
+	// No approval -> timeout -> 407.
 	if status != http.StatusProxyAuthRequired {
-		t.Errorf("expected 407 for anonymous unapproved CONNECT, got %d", status)
+		t.Errorf("expected 407 for unapproved CONNECT, got %d", status)
 	}
 }
 
 func TestProxy_CONNECT_HostNotApproved(t *testing.T) {
-	p, skills, _ := setupProxy(t)
-	skills.AddSkill(auth.Skill{ID: "s1", Token: "tok-1", Active: true})
+	p, _, _ := setupProxy(t)
 
 	proxyAddr, cleanup := startProxyServer(t, p)
 	defer cleanup()
 
-	status, conn := connectViaProxy(t, proxyAddr, "blocked.com:443", map[string]string{AuthHeader: "tok-1"})
+	status, conn := connectViaProxy(t, proxyAddr, "blocked.com:443", nil)
 	defer conn.Close()
 
 	// No approval exists, times out waiting → 407.
@@ -129,7 +127,7 @@ func TestProxy_CONNECT_HostNotApproved(t *testing.T) {
 // the client TLS, reads the inner HTTP request, injects credentials, and
 // forwards to the real HTTPS backend.
 func TestProxy_MITM_InspectsHTTPS(t *testing.T) {
-	p, skills, _, ca := setupProxyWithCA(t)
+	p, _, approvals, ca := setupProxyWithCA(t)
 
 	var receivedAuth string
 	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -142,10 +140,8 @@ func TestProxy_MITM_InspectsHTTPS(t *testing.T) {
 	backendURL, _ := url.Parse(backend.URL)
 	_, backendPort, _ := net.SplitHostPort(backendURL.Host)
 
-	skills.AddSkill(auth.Skill{
-		ID: "s1", Token: "tok-1", Active: true,
-		AllowedHost: []string{"127.0.0.1"},
-	})
+	// Approve the host via approval manager.
+	approvals.Decide("127.0.0.1", "", "", "", StatusApproved, "test")
 
 	p.Credentials.Add(credentials.Credential{
 		ID:            "cred-1",
@@ -160,8 +156,7 @@ func TestProxy_MITM_InspectsHTTPS(t *testing.T) {
 	proxyAddr, cleanup := startProxyServer(t, p)
 	defer cleanup()
 
-	status, proxyConn := connectViaProxy(t, proxyAddr, fmt.Sprintf("127.0.0.1:%s", backendPort),
-		map[string]string{AuthHeader: "tok-1"})
+	status, proxyConn := connectViaProxy(t, proxyAddr, fmt.Sprintf("127.0.0.1:%s", backendPort), nil)
 	defer proxyConn.Close()
 
 	if status != 200 {
@@ -203,17 +198,13 @@ func TestProxy_MITM_InspectsHTTPS(t *testing.T) {
 // TestProxy_MITM_HostCertVerifiable checks that the MITM'd connection
 // presents a valid certificate for the target host.
 func TestProxy_MITM_HostCertVerifiable(t *testing.T) {
-	p, skills, _, ca := setupProxyWithCA(t)
-	skills.AddSkill(auth.Skill{
-		ID: "s1", Token: "tok-1", Active: true,
-		AllowedHost: []string{"test.example.com"},
-	})
+	p, _, approvals, ca := setupProxyWithCA(t)
+	approvals.Decide("test.example.com", "", "", "", StatusApproved, "test")
 
 	proxyAddr, cleanup := startProxyServer(t, p)
 	defer cleanup()
 
-	status, proxyConn := connectViaProxy(t, proxyAddr, "test.example.com:443",
-		map[string]string{AuthHeader: "tok-1"})
+	status, proxyConn := connectViaProxy(t, proxyAddr, "test.example.com:443", nil)
 	defer proxyConn.Close()
 
 	if status != 200 {
@@ -246,7 +237,7 @@ func TestProxy_MITM_HostCertVerifiable(t *testing.T) {
 // TestProxy_MITM_ChunkedResponseComplete verifies that large chunked
 // responses are fully delivered through the MITM proxy without hanging.
 func TestProxy_MITM_ChunkedResponseComplete(t *testing.T) {
-	p, skills, _, ca := setupProxyWithCA(t)
+	p, _, approvals, ca := setupProxyWithCA(t)
 
 	largeBody := make([]byte, 100*1024)
 	for i := range largeBody {
@@ -263,18 +254,15 @@ func TestProxy_MITM_ChunkedResponseComplete(t *testing.T) {
 	backendURL, _ := url.Parse(backend.URL)
 	_, backendPort, _ := net.SplitHostPort(backendURL.Host)
 
-	skills.AddSkill(auth.Skill{
-		ID: "s1", Token: "tok-1", Active: true,
-		AllowedHost: []string{"127.0.0.1"},
-	})
+	// Approve the host via approval manager.
+	approvals.Decide("127.0.0.1", "", "", "", StatusApproved, "test")
 
 	p.Transport = backend.Client().Transport
 
 	proxyAddr, cleanup := startProxyServer(t, p)
 	defer cleanup()
 
-	status, proxyConn := connectViaProxy(t, proxyAddr, fmt.Sprintf("127.0.0.1:%s", backendPort),
-		map[string]string{AuthHeader: "tok-1"})
+	status, proxyConn := connectViaProxy(t, proxyAddr, fmt.Sprintf("127.0.0.1:%s", backendPort), nil)
 	defer proxyConn.Close()
 
 	if status != 200 {

--- a/internal/proxy/proxy_helm_test.go
+++ b/internal/proxy/proxy_helm_test.go
@@ -32,7 +32,7 @@ func TestProxy_HelmChart_CertManager_Approved(t *testing.T) {
 	req.Host = "charts.jetstack.io"
 	req.RemoteAddr = "10.0.0.1:12345"
 
-	resp, _ := p.processRequest(req, "10.0.0.1", nil)
+	resp, _ := p.processRequest(req, "10.0.0.1")
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("approved cert-manager chart should return 200, got %d", resp.StatusCode)
@@ -50,7 +50,7 @@ func TestProxy_HelmChart_CertManager_Denied(t *testing.T) {
 	req.Host = "charts.jetstack.io"
 	req.RemoteAddr = "10.0.0.1:12345"
 
-	resp, _ := p.processRequest(req, "10.0.0.1", nil)
+	resp, _ := p.processRequest(req, "10.0.0.1")
 
 	if resp.StatusCode != http.StatusProxyAuthRequired {
 		t.Errorf("unapproved cert-manager chart should return 407 (pending timeout), got %d", resp.StatusCode)
@@ -81,7 +81,7 @@ func TestProxy_HelmChart_IndexYaml_CreatesRepoEntry(t *testing.T) {
 	req.Host = "charts.jetstack.io"
 	req.RemoteAddr = "10.0.0.1:12345"
 
-	resp, _ := p.processRequest(req, "10.0.0.1", nil)
+	resp, _ := p.processRequest(req, "10.0.0.1")
 
 	// index.yaml creates a pending repo-level entry (no longer auto-approved).
 	if resp.StatusCode != http.StatusProxyAuthRequired {
@@ -124,7 +124,7 @@ func TestProxy_HelmChart_IndexYaml_ApprovedRepo(t *testing.T) {
 	req.Host = "charts.jetstack.io"
 	req.RemoteAddr = "10.0.0.1:12345"
 
-	resp, _ := p.processRequest(req, "10.0.0.1", nil)
+	resp, _ := p.processRequest(req, "10.0.0.1")
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("approved repo index.yaml should return 200, got %d", resp.StatusCode)
@@ -153,7 +153,7 @@ func TestProxy_HelmChart_RepoApproval_CoversCharts(t *testing.T) {
 	req.Host = "charts.jetstack.io"
 	req.RemoteAddr = "10.0.0.1:12345"
 
-	resp, _ := p.processRequest(req, "10.0.0.1", nil)
+	resp, _ := p.processRequest(req, "10.0.0.1")
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("chart from approved repo should return 200, got %d", resp.StatusCode)
@@ -180,7 +180,7 @@ func TestProxy_HelmChart_LearningMode_CertManager(t *testing.T) {
 	req.Host = "charts.jetstack.io"
 	req.RemoteAddr = "10.0.0.1:12345"
 
-	resp, _ := p.processRequest(req, "10.0.0.1", nil)
+	resp, _ := p.processRequest(req, "10.0.0.1")
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("learning mode: cert-manager chart should be allowed, got %d", resp.StatusCode)

--- a/internal/proxy/proxy_http.go
+++ b/internal/proxy/proxy_http.go
@@ -37,7 +37,7 @@ func (p *Proxy) onRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Reque
 		p.OnActivity(sourceIP)
 	}
 
-	resp, rc := p.processRequest(req, sourceIP, nil)
+	resp, rc := p.processRequest(req, sourceIP)
 	ctx.UserData = rc
 	return req, resp
 }
@@ -49,15 +49,12 @@ func (p *Proxy) onResponse(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Res
 }
 
 // processRequest handles the shared business logic for all request types:
-// authentication, routing to specialized handlers, approval checking,
+// routing to specialized handlers, approval checking,
 // credential injection, forwarding, and logging.
-//
-// If preAuthSkill is non-nil, it is used directly (e.g., from CONNECT auth).
-// If preAuthSkill is nil, authentication is attempted from the request headers.
 //
 // Returns the response to send to the client. The returned requestContext
 // contains logging state.
-func (p *Proxy) processRequest(req *http.Request, sourceIP string, preAuthSkill *auth.Skill) (*http.Response, *requestContext) {
+func (p *Proxy) processRequest(req *http.Request, sourceIP string) (*http.Response, *requestContext) {
 	start := time.Now()
 	host := extractHost(req)
 
@@ -66,32 +63,7 @@ func (p *Proxy) processRequest(req *http.Request, sourceIP string, preAuthSkill 
 		host:     host,
 		sourceIP: sourceIP,
 	}
-
-	// Authenticate.
-	var skill *auth.Skill
-	if preAuthSkill != nil {
-		skill = preAuthSkill
-	} else {
-		var err error
-		skill, err = p.authenticateOptional(req)
-		if err != nil {
-			p.Logger.Add(proxylog.Entry{
-				Method: req.Method,
-				Host:   host,
-				Path:   req.URL.Path,
-				Status: "denied",
-				Detail: "auth failed: " + err.Error(),
-			})
-			rc.logged = true
-			return errorResponse(req, http.StatusProxyAuthRequired,
-				"Proxy authentication failed: "+err.Error()), rc
-		}
-	}
-	rc.skill = skill
-	sid := getSkillID(skill)
-
-	// Remove our custom header before forwarding.
-	req.Header.Del(AuthHeader)
+	sid := getSkillID(rc.skill)
 
 	// Route to specialized handlers.
 	if reg := registry.RegistryForHost(host, p.Registries); reg != nil {
@@ -108,7 +80,7 @@ func (p *Proxy) processRequest(req *http.Request, sourceIP string, preAuthSkill 
 	}
 
 	// Generic host+path approval.
-	status := p.checkApproval(host, req.URL.Path, skill, sourceIP)
+	status := p.checkApproval(host, req.URL.Path, rc.skill, sourceIP)
 	if status != approval.StatusApproved {
 		resource := host + req.URL.Path
 		p.Logger.Add(proxylog.Entry{
@@ -124,7 +96,7 @@ func (p *Proxy) processRequest(req *http.Request, sourceIP string, preAuthSkill 
 	}
 
 	// Check logging mode before injecting credentials (capture pre-injection headers).
-	logMode := p.getLoggingMode(host, req.URL.Path, skill, sourceIP)
+	logMode := p.getLoggingMode(host, req.URL.Path, rc.skill, sourceIP)
 	rc.logMode = logMode
 	if logMode == approval.LoggingModeFull {
 		reqBody := captureRequestBody(req)

--- a/internal/proxy/proxy_registry_test.go
+++ b/internal/proxy/proxy_registry_test.go
@@ -28,7 +28,7 @@ func TestProxy_LearningMode_RegistryBlob(t *testing.T) {
 	blobReq.Host = "registry.example.com"
 	blobReq.RemoteAddr = "10.0.0.1:12345"
 
-	resp, _ := p.processRequest(blobReq, "10.0.0.1", nil)
+	resp, _ := p.processRequest(blobReq, "10.0.0.1")
 
 	if resp.StatusCode == http.StatusForbidden {
 		t.Error("learning mode: blob request should not be denied (got 403)")
@@ -60,7 +60,7 @@ func TestProxy_LearningMode_RegistryBlob_DeniedWhenOff(t *testing.T) {
 	blobReq.Host = "registry.example.com"
 	blobReq.RemoteAddr = "10.0.0.1:12345"
 
-	resp, _ := p.processRequest(blobReq, "10.0.0.1", nil)
+	resp, _ := p.processRequest(blobReq, "10.0.0.1")
 
 	if resp.StatusCode != http.StatusForbidden {
 		t.Errorf("default-deny: blob request should be denied, got %d", resp.StatusCode)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -103,37 +103,22 @@ func TestGetSkillID(t *testing.T) {
 	}
 }
 
-func TestProxy_NoAuthHeader_Anonymous(t *testing.T) {
+func TestProxy_Anonymous_Unapproved(t *testing.T) {
 	p, _, _ := setupProxy(t)
 	req := httptest.NewRequest("GET", "http://example.com/test", nil)
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 
-	// Without token, request is anonymous. No approval exists, so it times
-	// out waiting for admin approval (407).
+	// No approval exists, so it times out waiting for admin approval (407).
 	if w.Code != http.StatusProxyAuthRequired {
 		t.Errorf("expected 407 for anonymous unapproved host, got %d", w.Code)
 	}
 }
 
-func TestProxy_InvalidToken(t *testing.T) {
-	p, _, _ := setupProxy(t)
-	req := httptest.NewRequest("GET", "http://example.com/test", nil)
-	req.Header.Set(AuthHeader, "bad-token")
-	w := httptest.NewRecorder()
-	p.ServeHTTP(w, req)
-
-	if w.Code != http.StatusProxyAuthRequired {
-		t.Errorf("expected 407, got %d", w.Code)
-	}
-}
-
 func TestProxy_HostNotApproved(t *testing.T) {
-	p, skills, _ := setupProxy(t)
-	skills.AddSkill(auth.Skill{ID: "s1", Token: "tok-1", Active: true})
+	p, _, _ := setupProxy(t)
 
 	req := httptest.NewRequest("GET", "http://blocked.com/test", nil)
-	req.Header.Set(AuthHeader, "tok-1")
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 
@@ -143,34 +128,9 @@ func TestProxy_HostNotApproved(t *testing.T) {
 	}
 }
 
-func TestProxy_PreApprovedHost(t *testing.T) {
-	p, skills, _ := setupProxy(t)
-	skills.AddSkill(auth.Skill{
-		ID: "s1", Token: "tok-1", Active: true,
-		AllowedHost: []string{"target.example.com"},
-	})
-
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("hello from backend"))
-	}))
-	defer backend.Close()
-
-	req := httptest.NewRequest("GET", backend.URL+"/test", nil)
-	req.Host = "target.example.com"
-	req.Header.Set(AuthHeader, "tok-1")
-	w := httptest.NewRecorder()
-	p.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d", w.Code)
-	}
-}
-
 func TestProxy_ApprovedHost(t *testing.T) {
-	p, skills, approvals := setupProxy(t)
-	skills.AddSkill(auth.Skill{ID: "s1", Token: "tok-1", Active: true})
-	approvals.Decide("target.example.com", "s1", "", "", approval.StatusApproved, "ok")
+	p, _, approvals := setupProxy(t)
+	approvals.Decide("target.example.com", "", "", "", approval.StatusApproved, "ok")
 
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -179,7 +139,6 @@ func TestProxy_ApprovedHost(t *testing.T) {
 
 	req := httptest.NewRequest("GET", backend.URL+"/data", nil)
 	req.Host = "target.example.com"
-	req.Header.Set(AuthHeader, "tok-1")
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 
@@ -199,38 +158,14 @@ func TestProxy_GlobalApproval(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	// Anonymous request (no token) should pass via global approval.
+	// Anonymous request should pass via global approval.
 	req := httptest.NewRequest("GET", backend.URL+"/test", nil)
 	req.Host = "global.example.com"
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
-		t.Errorf("expected 200 for globally approved host (anonymous), got %d", w.Code)
-	}
-}
-
-func TestProxy_GlobalApproval_WithSkill(t *testing.T) {
-	p, skills, approvals := setupProxy(t)
-	skills.AddSkill(auth.Skill{ID: "s1", Token: "tok-1", Active: true})
-
-	// Globally approve a host.
-	approvals.Decide("global.example.com", "", "", "", approval.StatusApproved, "global")
-
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer backend.Close()
-
-	// Authenticated request should also pass via global approval.
-	req := httptest.NewRequest("GET", backend.URL+"/test", nil)
-	req.Host = "global.example.com"
-	req.Header.Set(AuthHeader, "tok-1")
-	w := httptest.NewRecorder()
-	p.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200 for globally approved host (with skill), got %d", w.Code)
+		t.Errorf("expected 200 for globally approved host, got %d", w.Code)
 	}
 }
 
@@ -276,54 +211,6 @@ func TestProxy_WildcardGlobalApproval(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200 for wildcard-approved host, got %d", w.Code)
-	}
-}
-
-func TestProxy_WildcardPreApprovedHost(t *testing.T) {
-	p, skills, _ := setupProxy(t)
-	skills.AddSkill(auth.Skill{
-		ID: "s1", Token: "tok-1", Active: true,
-		AllowedHost: []string{"*.example.com"},
-	})
-
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer backend.Close()
-
-	req := httptest.NewRequest("GET", backend.URL+"/test", nil)
-	req.Host = "api.example.com"
-	req.Header.Set(AuthHeader, "tok-1")
-	w := httptest.NewRecorder()
-	p.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200 for wildcard pre-approved host, got %d", w.Code)
-	}
-}
-
-func TestProxy_AuthHeaderStripped(t *testing.T) {
-	p, skills, _ := setupProxy(t)
-	skills.AddSkill(auth.Skill{
-		ID: "s1", Token: "tok-1", Active: true,
-		AllowedHost: []string{"target.example.com"},
-	})
-
-	var gotHeader string
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotHeader = r.Header.Get(AuthHeader)
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer backend.Close()
-
-	req := httptest.NewRequest("GET", backend.URL+"/test", nil)
-	req.Host = "target.example.com"
-	req.Header.Set(AuthHeader, "tok-1")
-	w := httptest.NewRecorder()
-	p.ServeHTTP(w, req)
-
-	if gotHeader != "" {
-		t.Error("auth header should be stripped before forwarding")
 	}
 }
 
@@ -391,8 +278,7 @@ func TestProxy_HostApproval_CoversAllPaths(t *testing.T) {
 // --- Learning mode tests ---
 
 func TestProxy_LearningMode(t *testing.T) {
-	p, skills, approvals := setupProxy(t)
-	skills.AddSkill(auth.Skill{ID: "s1", Token: "tok-1", Active: true})
+	p, _, approvals := setupProxy(t)
 	p.LearningMode = true
 
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -403,7 +289,6 @@ func TestProxy_LearningMode(t *testing.T) {
 
 	req := httptest.NewRequest("GET", backend.URL+"/test", nil)
 	req.Host = "unapproved.example.com"
-	req.Header.Set(AuthHeader, "tok-1")
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 
@@ -426,12 +311,10 @@ func TestProxy_LearningMode(t *testing.T) {
 }
 
 func TestProxy_LearningModeDisabled(t *testing.T) {
-	p, skills, _ := setupProxy(t)
-	skills.AddSkill(auth.Skill{ID: "s1", Token: "tok-1", Active: true})
+	p, _, _ := setupProxy(t)
 	p.LearningMode = false // default-deny
 
 	req := httptest.NewRequest("GET", "http://blocked.com/test", nil)
-	req.Header.Set(AuthHeader, "tok-1")
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 

--- a/internal/proxy/proxy_transparent.go
+++ b/internal/proxy/proxy_transparent.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"strings"
 
 	proxylog "github.com/olljanat-ai/firewall4ai/internal/logging"
 )
@@ -89,39 +88,15 @@ func (p *Proxy) HandleTransparentTLS(clientConn net.Conn) {
 	}
 }
 
-// handleTransparentTLSRequest authenticates a request from a transparent TLS
-// connection and processes it via processRequest.
+// handleTransparentTLSRequest processes a request from a transparent TLS
+// connection via processRequest.
 func (p *Proxy) handleTransparentTLSRequest(clientConn net.Conn, req *http.Request, host, sourceIP string) {
 	// Set URL for HTTPS forwarding.
 	req.URL.Scheme = "https"
 	req.URL.Host = host + ":443"
 	req.Host = host
 
-	// Authenticate from the inner request (transparent mode).
-	skill, err := p.authenticateOptional(req)
-	if err != nil {
-		p.Logger.Add(proxylog.Entry{
-			Method: req.Method,
-			Host:   host,
-			Path:   req.URL.Path,
-			Status: "denied",
-			Detail: "auth failed: " + err.Error(),
-		})
-		msg := "Firewall4AI: Proxy authentication failed: " + err.Error()
-		resp := &http.Response{
-			StatusCode: http.StatusProxyAuthRequired,
-			ProtoMajor: 1,
-			ProtoMinor: 1,
-			Header:     make(http.Header),
-			Body:       io.NopCloser(strings.NewReader(msg + "\n")),
-		}
-		resp.Header.Set("Content-Type", "text/plain; charset=utf-8")
-		resp.ContentLength = int64(len(msg) + 1)
-		resp.Write(clientConn)
-		return
-	}
-
-	resp, _ := p.processRequest(req, sourceIP, skill)
+	resp, _ := p.processRequest(req, sourceIP)
 
 	// Write response to the TLS connection.
 	forwardTLS(clientConn, resp)


### PR DESCRIPTION
This PR removes the token-based authentication system and pre-approved host lists from the proxy, shifting to a purely approval-based access control model where all access decisions are made through the centralized approval manager.

## Summary
The authentication system based on `X-Firewall4AI-Token` headers and skill tokens has been removed. Access control now relies entirely on the approval manager, with agents identified by their source IP rather than tokens. This simplifies the security model and centralizes all authorization decisions.

## Key Changes

- **Removed token authentication**: Deleted `authenticateOptional()` method and all token validation logic from the proxy
- **Removed pre-approved hosts**: Deleted `AllowedHost` field from `Skill` struct and removed `IsHostPreApproved()` and `Authenticate()` methods from `SkillStore`
- **Simplified SkillStore**: Removed token-based lookup map (`s.skills`), keeping only ID-based lookups (`s.byID`)
- **Updated approval checks**: Removed pre-approval checks in `checkApproval()` that bypassed the approval manager
- **Removed AuthHeader constant**: Deleted the `X-Firewall4AI-Token` header definition and all header handling code
- **Simplified request processing**: Removed skill authentication from `processRequest()`, `handleConnectDecision()`, and `handleTransparentTLSRequest()`
- **Updated tests**: Removed all test cases for token authentication, pre-approved hosts, and invalid tokens; updated remaining tests to use approval-based access control

## Implementation Details

- Agents are now identified by source IP for approval lookups instead of skill tokens
- The `Skill` struct is now primarily used for metadata (ID, name, description, token) rather than access control
- All access decisions flow through the approval manager's `CheckExistingWithPath()` method
- The `requestContext` no longer carries skill information for authorization purposes
- Transparent TLS and CONNECT tunneling now use approval-based checks exclusively

https://claude.ai/code/session_01L1LdEJPdQb3gJouYzM9M4i