### PR TITLE
Add transparent HTTP proxy support for relative URL requests

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -103,6 +103,40 @@ func New(skills *auth.SkillStore, approvals *approval.Manager, creds *credential
 	gp.Verbose = false
 	gp.Logger = &goproxyLogBridge{logger: logger}
 
+	// NonproxyHandler handles transparent HTTP requests that arrive with
+	// relative URLs (from iptables REDIRECT of port 80 -> 8080). We
+	// reconstruct the full URL from the Host header and delegate to
+	// processRequest for approval checking and forwarding.
+	gp.NonproxyHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Host == "" {
+			http.Error(w, "Firewall4AI: transparent request with no Host header", http.StatusBadRequest)
+			return
+		}
+		req.URL.Scheme = "http"
+		req.URL.Host = req.Host
+
+		sourceIP := extractSourceIP(req.RemoteAddr)
+		if p.OnActivity != nil {
+			p.OnActivity(sourceIP)
+		}
+
+		resp, _ := p.processRequest(req, sourceIP)
+		if resp == nil {
+			http.Error(w, "Firewall4AI: no response from upstream", http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+
+		// Copy response headers and status.
+		for k, vv := range resp.Header {
+			for _, v := range vv {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		io.Copy(w, resp.Body)
+	})
+
 	// CONNECT handler: decide MITM vs blind tunnel vs reject.
 	gp.OnRequest().HandleConnect(goproxy.FuncHttpsHandler(p.handleConnectDecision))
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -275,6 +275,64 @@ func TestProxy_HostApproval_CoversAllPaths(t *testing.T) {
 	}
 }
 
+// --- Transparent HTTP tests ---
+
+func TestProxy_TransparentHTTP_Approved(t *testing.T) {
+	p, _, approvals := setupProxy(t)
+	approvals.Decide("transparent.example.com", "", "", "", StatusApproved, "ok")
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("transparent ok"))
+	}))
+	defer backend.Close()
+
+	// Redirect transport so the request goes to our test backend.
+	p.Transport = &testRedirectTransport{
+		inner:      http.DefaultTransport,
+		targetHost: backend.Listener.Addr().String(),
+	}
+
+	// Simulate transparent redirect: relative URL, Host header set by client.
+	req := httptest.NewRequest("GET", "/data", nil)
+	req.Host = "transparent.example.com"
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for transparent HTTP approved host, got %d", w.Code)
+	}
+}
+
+func TestProxy_TransparentHTTP_Unapproved(t *testing.T) {
+	p, _, _ := setupProxy(t)
+
+	// Simulate transparent redirect: relative URL, no approval.
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Host = "blocked.example.com"
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	// No approval → times out → 407.
+	if w.Code != http.StatusProxyAuthRequired {
+		t.Errorf("expected 407 for transparent HTTP unapproved host, got %d", w.Code)
+	}
+}
+
+func TestProxy_TransparentHTTP_NoHost(t *testing.T) {
+	p, _, _ := setupProxy(t)
+
+	// Transparent redirect with no Host header should return 400.
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Host = ""
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for transparent HTTP with no Host header, got %d", w.Code)
+	}
+}
+
 // --- Learning mode tests ---
 
 func TestProxy_LearningMode(t *testing.T) {


### PR DESCRIPTION
## Summary
This PR adds support for transparent HTTP proxying, enabling the proxy to handle requests that arrive with relative URLs and a Host header (typical of iptables REDIRECT rules). The implementation reconstructs the full URL from the Host header and processes the request through the standard approval and forwarding pipeline.

## Key Changes
- **NonproxyHandler implementation**: Added a handler in `proxy.go` that intercepts transparent HTTP requests with relative URLs
  - Validates that a Host header is present (returns 400 Bad Request if missing)
  - Reconstructs the full URL by combining the relative path with the Host header
  - Extracts source IP and triggers activity callbacks
  - Delegates to `processRequest()` for approval checking and forwarding
  - Properly copies response headers and body back to the client

- **Comprehensive test coverage**: Added three test cases in `proxy_test.go`
  - `TestProxy_TransparentHTTP_Approved`: Verifies approved transparent requests are forwarded successfully
  - `TestProxy_TransparentHTTP_Unapproved`: Confirms unapproved requests return 407 Proxy Authentication Required
  - `TestProxy_TransparentHTTP_NoHost`: Validates that requests without a Host header return 400 Bad Request

## Implementation Details
- The NonproxyHandler is registered with goproxy's standard handler mechanism
- Source IP extraction and activity tracking are integrated into the transparent request flow
- Error handling covers missing Host headers and upstream failures (502 Bad Gateway)
- Response forwarding preserves all headers and status codes from the upstream server

https://claude.ai/code/session_01TAGyQheAEGVg3XaKuuvscw