### PR TITLE
Fix waiter channel leak on approval timeout

### DIFF
--- a/internal/approval/approval.go
+++ b/internal/approval/approval.go
@@ -230,6 +230,20 @@ func (m *Manager) WaitForDecision(host, skillID, sourceIP, pathPrefix string, ti
 	case status := <-ch:
 		return status
 	case <-timer.C:
+		// Clean up the timed-out channel to prevent a memory leak.
+		m.mu.Lock()
+		if waiters, ok := m.waiters[k]; ok {
+			for i, w := range waiters {
+				if w == ch {
+					m.waiters[k] = append(waiters[:i], waiters[i+1:]...)
+					break
+				}
+			}
+			if len(m.waiters[k]) == 0 {
+				delete(m.waiters, k)
+			}
+		}
+		m.mu.Unlock()
 		return StatusPendingTimeout // timeout = still waiting for admin
 	}
 }


### PR DESCRIPTION
When WaitForDecision times out, the goroutine's channel remains in the waiters map indefinitely.  Each timed-out request leaves a dangling channel reference that is never cleaned up, causing unbounded memory growth under sustained traffic.

Remove the channel from the waiters slice on timeout, and delete the map entry when the slice becomes empty.