### PR TITLE
Validate OCI image reference in systemUpgrade endpoint

### DIFF
--- a/internal/api/api_settings.go
+++ b/internal/api/api_settings.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"net/http"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -77,6 +78,10 @@ func (h *Handler) systemLogs(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"logs": string(out)})
 }
 
+// validOCIRef matches standard OCI image references:
+// registry/path:tag or registry/path@sha256:digest
+var validOCIRef = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?(/[a-zA-Z0-9._-]+)+(:[a-zA-Z0-9._-]+)?(@sha256:[a-f0-9]{64})?$`)
+
 func (h *Handler) systemUpgrade(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Image string `json:"image"`
@@ -88,6 +93,10 @@ func (h *Handler) systemUpgrade(w http.ResponseWriter, r *http.Request) {
 	image := strings.TrimSpace(req.Image)
 	if image == "" {
 		image = "ghcr.io/olljanat-ai/firewall4ai:latest"
+	}
+	if !validOCIRef.MatchString(image) {
+		http.Error(w, "invalid image reference", http.StatusBadRequest)
+		return
 	}
 	log.Printf("System upgrade requested with image: %s", image)
 	// Run upgrade in background since it will reboot.


### PR DESCRIPTION
The upgrade endpoint passes a user-provided image name to exec.Command("elemental", "upgrade", ...).  While Go's exec.Command does not invoke a shell (so classic injection is not possible), an unrestricted image string could inject flags (e.g. "--some-flag") or reference unexpected registries.

Add a regex that validates the image matches a standard OCI reference (registry/path:tag or @sha256:digest) before passing it through.