### PR TITLE
Add 1MB request body size limit to API endpoints

### DIFF
--- a/internal/api/agentapi.go
+++ b/internal/api/agentapi.go
@@ -277,7 +277,7 @@ func (h *AgentHandler) queryDatabase(w http.ResponseWriter, r *http.Request) {
 		Args  []interface{} `json:"args"`
 	}
 	defer r.Body.Close()
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxRequestBodySize)).Decode(&req); err != nil {
 		http.Error(w, "Firewall4AI: invalid request body", http.StatusBadRequest)
 		return
 	}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -176,9 +176,13 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	json.NewEncoder(w).Encode(v)
 }
 
+// maxRequestBodySize is the maximum allowed request body size (1 MB).
+const maxRequestBodySize = 1 << 20
+
 func readJSON(r *http.Request, v any) error {
 	defer r.Body.Close()
-	return json.NewDecoder(r.Body).Decode(v)
+	limited := http.MaxBytesReader(nil, r.Body, maxRequestBodySize)
+	return json.NewDecoder(limited).Decode(v)
 }
 
 func (h *Handler) save() {


### PR DESCRIPTION
readJSON and the agent queryDatabase handler decode request bodies without any size limit, allowing a malicious client to exhaust server memory with an oversized POST body.  Wrap r.Body with http.MaxBytesReader (1 MB cap) before decoding.  The restore endpoint already had its own 50 MB limit and is unaffected.