### PR TITLE
Check rand.Read error in GenerateGUID

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -33,7 +33,9 @@ func NewSkillStore() *SkillStore {
 // GenerateGUID creates a cryptographically random UUID v4 string.
 func GenerateGUID() string {
 	b := make([]byte, 16)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		panic("crypto/rand.Read failed: " + err.Error())
+	}
 	b[6] = (b[6] & 0x0f) | 0x40 // version 4
 	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
 	h := hex.EncodeToString(b)


### PR DESCRIPTION
crypto/rand.Read can fail if the system entropy source is unavailable. The error was silently ignored, which could produce predictable or zero-filled UUIDs. Panic on failure since this indicates a broken system where security guarantees cannot be met.