### PR TITLE
Limit unbounded io.ReadAll calls on external responses

### DIFF
--- a/internal/api/imagemgmt.go
+++ b/internal/api/imagemgmt.go
@@ -316,7 +316,7 @@ func (h *Handler) getRtkReleases(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20)) // 2 MB limit
 	if err != nil {
 		http.Error(w, "failed to read GitHub response", http.StatusBadGateway)
 		return

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -269,7 +269,8 @@ func errorResponse(req *http.Request, code int, msg string) *http.Response {
 // stays open (e.g. helm repo add with ~600KB index responses).
 func forwardTLS(conn net.Conn, resp *http.Response) {
 	if resp.ContentLength < 0 && resp.Body != nil {
-		body, _ := io.ReadAll(resp.Body)
+		const maxChunkedBody = 10 << 20 // 10 MB limit for buffering chunked responses
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxChunkedBody))
 		resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(body))
 		resp.ContentLength = int64(len(body))


### PR DESCRIPTION
Two io.ReadAll calls read external data without size limits:

1. getRtkReleases reads the GitHub API response into memory with no cap. Add a 2 MB limit via io.LimitReader — the GitHub releases JSON is typically a few KB.

2. forwardTLS buffers chunked upstream responses fully in memory to set Content-Length.  A malicious upstream could send an arbitrarily large body.  Add a 10 MB limit (the comment mentions ~600 KB as typical).