### PR TITLE
Fix data race on Proxy.LearningMode with atomic bool

### DIFF
--- a/cmd/firewall4ai/main.go
+++ b/cmd/firewall4ai/main.go
@@ -358,15 +358,15 @@ func main() {
 	p.HelmRepos = cfg.HelmRepos
 	p.OSPackages = cfg.OSPackages
 	p.CodeLibraries = cfg.CodeLibraries
-	p.LearningMode = config.Get().LearningMode
-	if p.LearningMode {
+	p.SetLearningMode(config.Get().LearningMode)
+	if p.GetLearningMode() {
 		log.Printf("Learning mode is ENABLED — all connections will be allowed by default")
 	}
 	p.OnActivity = func(sourceIP string) {
 		agentMgr.SetLastSeen(sourceIP)
 	}
 	apiHandler.SetLearningModeFunc = func(enabled bool) {
-		p.LearningMode = enabled
+		p.SetLearningMode(enabled)
 		if enabled {
 			log.Printf("Learning mode ENABLED — all connections will be allowed by default")
 		} else {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/elazarl/goproxy"
@@ -59,10 +60,20 @@ type Proxy struct {
 	Transport          http.RoundTripper
 	CA                 *certgen.CA
 	ApprovalTimeout    time.Duration
-	LearningMode       bool                  // when true, allow all traffic by default (still logged)
+	learningMode       atomic.Bool           // when true, allow all traffic by default (still logged)
 	OnActivity         func(sourceIP string) // called on each request with the source IP
 
 	goProxy *goproxy.ProxyHttpServer
+}
+
+// SetLearningMode atomically updates the learning mode flag.
+func (p *Proxy) SetLearningMode(enabled bool) {
+	p.learningMode.Store(enabled)
+}
+
+// GetLearningMode atomically reads the learning mode flag.
+func (p *Proxy) GetLearningMode() bool {
+	return p.learningMode.Load()
 }
 
 // goproxyLogBridge adapts our proxylog.Logger to goproxy's Logger interface,

--- a/internal/proxy/proxy_approval.go
+++ b/internal/proxy/proxy_approval.go
@@ -45,7 +45,7 @@ func (p *Proxy) checkApproval(host, path string, skill *auth.Skill, sourceIP str
 	}
 	status := p.Approvals.Check(host, sid, pendingIP, path)
 	if status == approval.StatusPending {
-		if p.LearningMode {
+		if p.GetLearningMode() {
 			return approval.StatusApproved
 		}
 		status = p.Approvals.WaitForDecision(host, sid, pendingIP, path, p.ApprovalTimeout)
@@ -85,7 +85,7 @@ func (p *Proxy) checkHostApproval(host string, skill *auth.Skill, sourceIP strin
 	}
 	status := p.Approvals.Check(host, sid, pendingIP, "")
 	if status == approval.StatusPending {
-		if p.LearningMode {
+		if p.GetLearningMode() {
 			return approval.StatusApproved
 		}
 		status = p.Approvals.WaitForDecision(host, sid, pendingIP, "", p.ApprovalTimeout)
@@ -126,7 +126,7 @@ func (p *Proxy) checkRefApproval(mgr *approval.Manager, ref string, skill *auth.
 	}
 	status := mgr.Check(ref, sid, pendingIP, "")
 	if status == approval.StatusPending {
-		if p.LearningMode {
+		if p.GetLearningMode() {
 			return approval.StatusApproved
 		}
 		return mgr.WaitForDecision(ref, sid, pendingIP, "", p.ApprovalTimeout)

--- a/internal/proxy/proxy_helm.go
+++ b/internal/proxy/proxy_helm.go
@@ -48,7 +48,7 @@ func helmRef(host, chartName string) string {
 // in HelmChartApprovals already covers the given ref — either by exact match or
 // because a repo-level approval covers a chart-level ref.
 func (p *Proxy) checkHelmApprovalFastPath(ref string) bool {
-	if p.LearningMode {
+	if p.GetLearningMode() {
 		return false // skip fast-path in learning mode; let checkRefApproval handle it
 	}
 	if status, ok := p.HelmChartApprovals.CheckExistingWithMatcher(ref, "", "", matchHelmRef); ok && status == approval.StatusApproved {

--- a/internal/proxy/proxy_helm_test.go
+++ b/internal/proxy/proxy_helm_test.go
@@ -172,7 +172,7 @@ func TestProxy_HelmChart_LearningMode_CertManager(t *testing.T) {
 	p.HelmRepos = []config.PackageRepoConfig{
 		{Name: "Jetstack", Type: "helm", Hosts: []string{"charts.jetstack.io"}},
 	}
-	p.LearningMode = true
+	p.SetLearningMode(true)
 	backendURL, _ := url.Parse(backend.URL)
 	p.Transport = &testRedirectTransport{inner: backend.Client().Transport, targetHost: backendURL.Host}
 

--- a/internal/proxy/proxy_packages.go
+++ b/internal/proxy/proxy_packages.go
@@ -73,7 +73,7 @@ func (p *Proxy) handlePackageRequest(req *http.Request, rc *requestContext, repo
 
 	// Package download: require explicit approval.
 	ref := packageRef(repo.Type, pkgName)
-	if library.CheckPackageApproval(mgr, pkgName) && !p.LearningMode {
+	if library.CheckPackageApproval(mgr, pkgName) && !p.GetLearningMode() {
 		// Fast-path: approved (wildcard or exact match).
 		p.Logger.Add(proxylog.Entry{
 			SkillID:  sid,

--- a/internal/proxy/proxy_packages_test.go
+++ b/internal/proxy/proxy_packages_test.go
@@ -82,7 +82,7 @@ func TestProxy_LearningMode_Package(t *testing.T) {
 	p.OSPackages = []config.PackageRepoConfig{
 		{Name: "Debian", Type: "debian", Hosts: []string{"deb.debian.org"}},
 	}
-	p.LearningMode = true
+	p.SetLearningMode(true)
 
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -119,7 +119,7 @@ func TestProxy_LearningMode_Library(t *testing.T) {
 	p.CodeLibraries = []config.PackageRepoConfig{
 		{Name: "Go Proxy", Type: "golang", Hosts: []string{"proxy.golang.org"}},
 	}
-	p.LearningMode = true
+	p.SetLearningMode(true)
 
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/proxy/proxy_registry.go
+++ b/internal/proxy/proxy_registry.go
@@ -27,8 +27,8 @@ func (p *Proxy) handleRegistryRequest(req *http.Request, rc *requestContext, reg
 	if isV2 && (pathType == "manifests" || pathType == "blobs") {
 		// Manifest and blob requests use repo-level approval.
 		repo := registry.ParseImageRepo(reg.Name, name)
-		if p.LearningMode || !registry.CheckRepoApproval(p.ImageApprovals, repo) {
-			if pathType == "blobs" && !p.LearningMode {
+		if p.GetLearningMode() || !registry.CheckRepoApproval(p.ImageApprovals, repo) {
+			if pathType == "blobs" && !p.GetLearningMode() {
 				// Blobs don't create pending entries; they are only
 				// allowed if the repo was already approved via a manifest.
 				p.Logger.Add(proxylog.Entry{

--- a/internal/proxy/proxy_registry_test.go
+++ b/internal/proxy/proxy_registry_test.go
@@ -21,7 +21,7 @@ func TestProxy_LearningMode_RegistryBlob(t *testing.T) {
 	p.Registries = []config.RegistryConfig{
 		{Name: "test-registry", Hosts: []string{"registry.example.com"}},
 	}
-	p.LearningMode = true
+	p.SetLearningMode(true)
 	p.Transport = backend.Client().Transport
 
 	blobReq, _ := http.NewRequest("GET", "https://registry.example.com:443/v2/myapp/blobs/sha256:abc123", nil)
@@ -54,7 +54,7 @@ func TestProxy_LearningMode_RegistryBlob_DeniedWhenOff(t *testing.T) {
 	p.Registries = []config.RegistryConfig{
 		{Name: "test-registry", Hosts: []string{"registry.example.com"}},
 	}
-	p.LearningMode = false // default-deny
+	p.SetLearningMode(false) // default-deny
 
 	blobReq, _ := http.NewRequest("GET", "https://registry.example.com:443/v2/myapp/blobs/sha256:abc123", nil)
 	blobReq.Host = "registry.example.com"

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -337,7 +337,7 @@ func TestProxy_TransparentHTTP_NoHost(t *testing.T) {
 
 func TestProxy_LearningMode(t *testing.T) {
 	p, _, approvals := setupProxy(t)
-	p.LearningMode = true
+	p.SetLearningMode(true)
 
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -370,7 +370,7 @@ func TestProxy_LearningMode(t *testing.T) {
 
 func TestProxy_LearningModeDisabled(t *testing.T) {
 	p, _, _ := setupProxy(t)
-	p.LearningMode = false // default-deny
+	p.SetLearningMode(false) // default-deny
 
 	req := httptest.NewRequest("GET", "http://blocked.com/test", nil)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
LearningMode was a plain bool read concurrently from proxy handler goroutines and written from the API handler. This is a data race detectable by go test -race.

Replace with sync/atomic.Bool and accessor methods SetLearningMode/ GetLearningMode. Update all read and write sites including tests.