### PR TITLE
Use atomic write-then-rename for JSON store persistence

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -48,7 +48,13 @@ func (s *JSONStore[T]) save() error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(s.path, data, 0o644)
+	// Atomic write: write to a temp file in the same directory, then rename.
+	// This prevents corruption if the process crashes mid-write.
+	tmpPath := s.path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, s.path)
 }
 
 // Get returns the current data (read-only snapshot).


### PR DESCRIPTION
os.WriteFile directly to the state file could leave a corrupted partial file if the process crashes mid-write. Switch to write-to-temp + os.Rename which is atomic on POSIX filesystems, preventing data loss.