### PR TITLE
Guard against nil response in MITM and transparent TLS handlers

### DIFF
--- a/internal/proxy/proxy_connect.go
+++ b/internal/proxy/proxy_connect.go
@@ -192,6 +192,10 @@ func (p *Proxy) handleMITM(clientConn net.Conn, host, targetAddr string, skill *
 		req.Host = host
 
 		resp, _ := p.processRequest(req, sourceIP)
+		if resp == nil {
+			write502TLS(tlsClientConn)
+			return
+		}
 
 		// Write response to the TLS connection.
 		forwardTLS(tlsClientConn, resp)

--- a/internal/proxy/proxy_transparent.go
+++ b/internal/proxy/proxy_transparent.go
@@ -97,6 +97,10 @@ func (p *Proxy) handleTransparentTLSRequest(clientConn net.Conn, req *http.Reque
 	req.Host = host
 
 	resp, _ := p.processRequest(req, sourceIP)
+	if resp == nil {
+		write502TLS(clientConn)
+		return
+	}
 
 	// Write response to the TLS connection.
 	forwardTLS(clientConn, resp)


### PR DESCRIPTION
processRequest could theoretically return nil in edge cases. The handleMITM and handleTransparentTLSRequest functions passed this nil directly to forwardTLS, which would panic on resp.ContentLength.

Add nil checks and send a 502 Bad Gateway instead.