### PR TITLE
Add support for Microsoft apt repository packages

### DIFF
--- a/config/firewall4ai/config.json
+++ b/config/firewall4ai/config.json
@@ -23,7 +23,8 @@
   "os_packages": [
     {"name": "Debian", "type": "debian", "hosts": ["deb.debian.org", "security.debian.org", "ftp.debian.org", "httpredir.debian.org", "cdn-fastly.deb.debian.org", "metadata.ftp-master.debian.org", "download.docker.com"]},
     {"name": "Alpine", "type": "alpine", "hosts": ["dl-cdn.alpinelinux.org", "dl-2.alpinelinux.org", "dl-3.alpinelinux.org", "dl-4.alpinelinux.org", "dl-5.alpinelinux.org"]},
-    {"name": "Ubuntu", "type": "ubuntu", "hosts": ["archive.ubuntu.com", "security.ubuntu.com", "ppa.launchpadcontent.net", "ppa.launchpad.net"]}
+    {"name": "Ubuntu", "type": "ubuntu", "hosts": ["archive.ubuntu.com", "security.ubuntu.com", "ppa.launchpadcontent.net", "ppa.launchpad.net"]},
+    {"name": "Microsoft", "type": "debian", "hosts": ["packages.microsoft.com"]}
   ],
   "code_libraries": [
     {"name": "Go Modules", "type": "golang", "hosts": ["proxy.golang.org", "sum.golang.org", "storage.googleapis.com"]},

--- a/internal/library/library_test.go
+++ b/internal/library/library_test.go
@@ -70,6 +70,29 @@ func TestParsePackageName_Debian(t *testing.T) {
 	}
 }
 
+func TestParsePackageName_Microsoft(t *testing.T) {
+	tests := []struct {
+		path string
+		name string
+		ok   bool
+	}{
+		// Microsoft apt repo uses /repos/<product>/pool/... and /repos/<product>/dists/...
+		{"/repos/azure-cli/pool/main/a/azure-cli/azure-cli_2.67.0-1~bookworm_all.deb", "azure-cli", true},
+		{"/repos/azure-cli/pool/main/p/python3-azext-devops/python3-azext-devops_1.0.1-1_all.deb", "python3-azext-devops", true},
+		{"/repos/azure-cli/dists/bookworm/main/binary-amd64/Packages", "", true},
+		{"/repos/azure-cli/dists/bookworm/InRelease", "", true},
+		// GPG key download — auto-approve as metadata
+		{"/keys/microsoft.asc", "", true},
+	}
+	for _, tt := range tests {
+		name, ok := ParsePackageName(tt.path, "debian")
+		if ok != tt.ok || name != tt.name {
+			t.Errorf("ParsePackageName(%q, debian) = (%q, %v), want (%q, %v)",
+				tt.path, name, ok, tt.name, tt.ok)
+		}
+	}
+}
+
 func TestParsePackageName_Go(t *testing.T) {
 	tests := []struct {
 		path string


### PR DESCRIPTION
## Summary
This change adds support for parsing and handling packages from Microsoft's apt repository (packages.microsoft.com), which uses a Debian-compatible package format.

## Key Changes
- Added `TestParsePackageName_Microsoft` test case to validate parsing of Microsoft apt repository paths
  - Tests parsing of `.deb` package files from Microsoft's pool structure (`/repos/<product>/pool/...`)
  - Tests handling of metadata files from the dists directory (`/repos/<product>/dists/...`)
  - Tests GPG key downloads as metadata files
- Added Microsoft repository configuration to `config.json`
  - Registered "packages.microsoft.com" as a Debian-type package source
  - Follows the same structure as existing Ubuntu and Debian entries

## Implementation Details
The Microsoft apt repository uses a similar structure to standard Debian repositories but with a `/repos/<product>/` prefix. The implementation leverages the existing Debian package parser by configuring Microsoft as a `debian` type repository, allowing reuse of existing parsing logic while supporting Microsoft's specific path conventions.

https://claude.ai/code/session_01JtHjVR87SgfundAm3UBjya

Closes #64