### PR TITLE
Implement P0 security hardening: at-rest secret encryption and log redaction

### DIFF
--- a/cmd/firewall4ai/main.go
+++ b/cmd/firewall4ai/main.go
@@ -29,6 +29,7 @@ import (
 	proxylog "github.com/olljanat-ai/firewall4ai/internal/logging"
 	"github.com/olljanat-ai/firewall4ai/internal/netboot"
 	"github.com/olljanat-ai/firewall4ai/internal/proxy"
+	"github.com/olljanat-ai/firewall4ai/internal/secret"
 	"github.com/olljanat-ai/firewall4ai/internal/store"
 	"github.com/olljanat-ai/firewall4ai/internal/tftp"
 	"github.com/olljanat-ai/firewall4ai/web"
@@ -75,6 +76,13 @@ func main() {
 	cfg, err := config.Load(*configPath)
 	if err != nil {
 		log.Fatalf("Failed to load config: %v", err)
+	}
+
+	// Initialize the master encryption key used to seal secret fields in
+	// state.json. Must happen before the store is loaded so that previously
+	// persisted ciphertext can be decrypted for the managers.
+	if err := secret.Init(cfg.DataDir); err != nil {
+		log.Fatalf("Failed to initialize secret store: %v", err)
 	}
 
 	// Initialize store.
@@ -133,8 +141,10 @@ func main() {
 	// Initialize TFTP server.
 	tftpServer := tftp.NewServer(":69", netbootMgr.TFTPDir())
 
-	// Load persisted state.
+	// Load persisted state. Decrypt sealed secrets in place so that the
+	// downstream managers only ever see plaintext values.
 	state := dataStore.Get()
+	openStateSecrets(&state)
 	skills.LoadSkills(state.Skills)
 	approvals.LoadApprovals(state.Approvals)
 	imageApprovals.LoadApprovals(state.ImageApprovals)
@@ -336,6 +346,8 @@ func main() {
 			d.Timezone = tz
 			d.SSHAuthorizedKeys = apiHandler.GetSSHAuthorizedKeysMap()
 			d.Templates = apiHandler.ExportTemplates()
+			// Encrypt secret fields before the store serializes to disk.
+			sealStateSecrets(d)
 		})
 	}
 	apiHandler.SaveFunc = saveFunc

--- a/cmd/firewall4ai/state_secrets.go
+++ b/cmd/firewall4ai/state_secrets.go
@@ -1,0 +1,38 @@
+package main
+
+import "github.com/olljanat-ai/firewall4ai/internal/secret"
+
+// sealStateSecrets encrypts every persisted secret field in d in place.
+// Idempotent — values already carrying the envelope prefix are left alone.
+func sealStateSecrets(d *storeData) {
+	for i := range d.Skills {
+		d.Skills[i].Token = secret.Seal(d.Skills[i].Token)
+	}
+	for i := range d.Creds {
+		d.Creds[i].Password = secret.Seal(d.Creds[i].Password)
+		d.Creds[i].Token = secret.Seal(d.Creds[i].Token)
+		d.Creds[i].HeaderValue = secret.Seal(d.Creds[i].HeaderValue)
+		d.Creds[i].ParamValue = secret.Seal(d.Creds[i].ParamValue)
+	}
+	for i := range d.Databases {
+		d.Databases[i].Password = secret.Seal(d.Databases[i].Password)
+	}
+}
+
+// openStateSecrets decrypts every persisted secret field in place before the
+// data is handed to runtime managers. Plaintext values from pre-encryption
+// state.json files pass through unchanged; the next save re-encrypts them.
+func openStateSecrets(d *storeData) {
+	for i := range d.Skills {
+		d.Skills[i].Token = secret.Open(d.Skills[i].Token)
+	}
+	for i := range d.Creds {
+		d.Creds[i].Password = secret.Open(d.Creds[i].Password)
+		d.Creds[i].Token = secret.Open(d.Creds[i].Token)
+		d.Creds[i].HeaderValue = secret.Open(d.Creds[i].HeaderValue)
+		d.Creds[i].ParamValue = secret.Open(d.Creds[i].ParamValue)
+	}
+	for i := range d.Databases {
+		d.Databases[i].Password = secret.Open(d.Databases[i].Password)
+	}
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -85,8 +85,12 @@ func NewPersistentLogger(maxSize int, logDir string) *Logger {
 	return l
 }
 
-// Add appends a new log entry and returns it.
+// Add appends a new log entry and returns it. Any FullDetail attached to the
+// entry is redacted in place before storage so that sensitive request/response
+// headers and known secret body fields are not persisted or served back.
 func (l *Logger) Add(e Entry) Entry {
+	RedactFullDetail(e.FullDetail)
+
 	l.mu.Lock()
 	e.ID = l.nextID
 	l.nextID++

--- a/internal/logging/redact.go
+++ b/internal/logging/redact.go
@@ -1,0 +1,180 @@
+package logging
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+)
+
+// RedactedPlaceholder is the string substituted for any header value, body
+// field, or credential value that logging must not expose.
+const RedactedPlaceholder = "***REDACTED***"
+
+// sensitiveHeaders lists HTTP header names (lowercased) whose values are
+// always redacted in stored log entries. Includes credentials Firewall4AI
+// itself injects via credentials.InjectForRequest so that they do not leak
+// through the log viewer or persisted JSONL on disk.
+var sensitiveHeaders = map[string]struct{}{
+	"authorization":       {},
+	"proxy-authorization": {},
+	"cookie":              {},
+	"set-cookie":          {},
+	"x-api-key":           {},
+	"x-auth-token":        {},
+	"x-access-token":      {},
+	"api-key":             {},
+}
+
+// sensitiveBodyFields lists JSON object keys and form field names
+// (lowercased) whose values are redacted in captured request/response bodies.
+var sensitiveBodyFields = map[string]struct{}{
+	"password":      {},
+	"passwd":        {},
+	"token":         {},
+	"secret":        {},
+	"api_key":       {},
+	"apikey":        {},
+	"access_token":  {},
+	"refresh_token": {},
+	"id_token":      {},
+	"authorization": {},
+	"client_secret": {},
+	"private_key":   {},
+}
+
+// IsSensitiveHeader reports whether the named header's value should never be
+// stored in plaintext in log entries.
+func IsSensitiveHeader(name string) bool {
+	_, ok := sensitiveHeaders[strings.ToLower(name)]
+	return ok
+}
+
+// RedactHeaders returns a copy of h with values of sensitive headers
+// replaced by RedactedPlaceholder. Non-sensitive headers are copied
+// unchanged. Returns nil for a nil input.
+func RedactHeaders(h map[string][]string) map[string][]string {
+	if h == nil {
+		return nil
+	}
+	out := make(map[string][]string, len(h))
+	for k, vals := range h {
+		if IsSensitiveHeader(k) {
+			red := make([]string, len(vals))
+			for i := range red {
+				red[i] = RedactedPlaceholder
+			}
+			out[k] = red
+			continue
+		}
+		out[k] = append([]string(nil), vals...)
+	}
+	return out
+}
+
+// RedactBody best-effort redacts known secret fields from a captured body.
+// It understands JSON (objects, arrays, nested) and application/x-www-form-
+// urlencoded payloads. For any other content type the body is returned
+// unchanged (we prefer false-negatives over corrupting unknown payloads).
+func RedactBody(contentType, body string) string {
+	if body == "" {
+		return body
+	}
+	ct := strings.ToLower(contentType)
+	switch {
+	case strings.Contains(ct, "application/json"), strings.Contains(ct, "+json"):
+		return redactJSONBody(body)
+	case strings.Contains(ct, "application/x-www-form-urlencoded"):
+		return redactFormBody(body)
+	default:
+		return body
+	}
+}
+
+func redactJSONBody(body string) string {
+	// Strip truncation marker so the decoder doesn't fail on it; reattach later.
+	const marker = "... (truncated)"
+	trimmed := body
+	truncated := false
+	if strings.HasSuffix(trimmed, marker) {
+		trimmed = strings.TrimSuffix(trimmed, marker)
+		truncated = true
+	}
+	var v any
+	if err := json.Unmarshal([]byte(trimmed), &v); err != nil {
+		return body
+	}
+	redactJSONValue(v)
+	out, err := json.Marshal(v)
+	if err != nil {
+		return body
+	}
+	if truncated {
+		return string(out) + marker
+	}
+	return string(out)
+}
+
+func redactJSONValue(v any) {
+	switch t := v.(type) {
+	case map[string]any:
+		for k, child := range t {
+			if _, bad := sensitiveBodyFields[strings.ToLower(k)]; bad {
+				t[k] = RedactedPlaceholder
+				continue
+			}
+			redactJSONValue(child)
+		}
+	case []any:
+		for i := range t {
+			redactJSONValue(t[i])
+		}
+	}
+}
+
+func redactFormBody(body string) string {
+	values, err := url.ParseQuery(body)
+	if err != nil {
+		return body
+	}
+	changed := false
+	for k, vals := range values {
+		if _, bad := sensitiveBodyFields[strings.ToLower(k)]; bad {
+			for i := range vals {
+				vals[i] = RedactedPlaceholder
+			}
+			values[k] = vals
+			changed = true
+		}
+	}
+	if !changed {
+		return body
+	}
+	return values.Encode()
+}
+
+// RedactFullDetail redacts sensitive headers and known secret body fields
+// in place. Safe to call with a nil pointer. Callers should invoke this
+// before the FullDetail is committed to storage or returned to clients.
+func RedactFullDetail(fd *FullDetail) {
+	if fd == nil {
+		return
+	}
+	reqCT := headerValue(fd.RequestHeaders, "Content-Type")
+	respCT := headerValue(fd.ResponseHeaders, "Content-Type")
+
+	fd.RequestHeaders = RedactHeaders(fd.RequestHeaders)
+	fd.InjectedHeaders = RedactHeaders(fd.InjectedHeaders)
+	fd.ResponseHeaders = RedactHeaders(fd.ResponseHeaders)
+	fd.RequestBody = RedactBody(reqCT, fd.RequestBody)
+	fd.ResponseBody = RedactBody(respCT, fd.ResponseBody)
+}
+
+func headerValue(h map[string][]string, name string) string {
+	lower := strings.ToLower(name)
+	for k, v := range h {
+		if strings.ToLower(k) == lower && len(v) > 0 {
+			return v[0]
+		}
+	}
+	return ""
+}

--- a/internal/logging/redact_test.go
+++ b/internal/logging/redact_test.go
@@ -1,0 +1,184 @@
+package logging
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRedactHeaders_RedactsSensitive(t *testing.T) {
+	in := map[string][]string{
+		"Authorization":       {"Bearer super-secret-token-xyz"},
+		"Proxy-Authorization": {"Basic dXNlcjpwYXNz"},
+		"Cookie":              {"session=abc123; other=ok"},
+		"X-Api-Key":           {"live_sk_XYZ"},
+		"Content-Type":        {"application/json"},
+		"User-Agent":          {"curl/8.0"},
+	}
+	out := RedactHeaders(in)
+
+	for _, name := range []string{"Authorization", "Proxy-Authorization", "Cookie", "X-Api-Key"} {
+		if got := out[name][0]; got != RedactedPlaceholder {
+			t.Errorf("%s not redacted: %q", name, got)
+		}
+	}
+	if got := out["Content-Type"][0]; got != "application/json" {
+		t.Errorf("Content-Type unexpectedly altered: %q", got)
+	}
+	if got := out["User-Agent"][0]; got != "curl/8.0" {
+		t.Errorf("User-Agent unexpectedly altered: %q", got)
+	}
+}
+
+func TestRedactHeaders_CaseInsensitive(t *testing.T) {
+	in := map[string][]string{"authorization": {"Bearer xyz"}}
+	out := RedactHeaders(in)
+	if out["authorization"][0] != RedactedPlaceholder {
+		t.Errorf("lowercase header not redacted")
+	}
+}
+
+func TestRedactHeaders_CopiesNonSensitive(t *testing.T) {
+	in := map[string][]string{"X-Trace-Id": {"abc"}}
+	out := RedactHeaders(in)
+	out["X-Trace-Id"][0] = "mutated"
+	if in["X-Trace-Id"][0] != "abc" {
+		t.Errorf("input mutated through shared backing array")
+	}
+}
+
+func TestRedactHeaders_Nil(t *testing.T) {
+	if got := RedactHeaders(nil); got != nil {
+		t.Errorf("nil in should produce nil out, got %v", got)
+	}
+}
+
+func TestRedactBody_JSONObject(t *testing.T) {
+	body := `{"user":"alice","password":"hunter2","token":"abc","nested":{"api_key":"k1","ok":"v"}}`
+	out := RedactBody("application/json", body)
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("redacted body is not valid JSON: %v", err)
+	}
+	if m["password"] != RedactedPlaceholder {
+		t.Errorf("password not redacted: %v", m["password"])
+	}
+	if m["token"] != RedactedPlaceholder {
+		t.Errorf("token not redacted: %v", m["token"])
+	}
+	nested := m["nested"].(map[string]any)
+	if nested["api_key"] != RedactedPlaceholder {
+		t.Errorf("nested api_key not redacted: %v", nested["api_key"])
+	}
+	if nested["ok"] != "v" {
+		t.Errorf("non-sensitive nested field altered: %v", nested["ok"])
+	}
+	if m["user"] != "alice" {
+		t.Errorf("non-sensitive field altered: %v", m["user"])
+	}
+}
+
+func TestRedactBody_JSONArrayOfObjects(t *testing.T) {
+	body := `[{"password":"p1"},{"password":"p2"}]`
+	out := RedactBody("application/json", body)
+	if strings.Contains(out, "p1") || strings.Contains(out, "p2") {
+		t.Errorf("plaintext password leaked through array redaction: %s", out)
+	}
+}
+
+func TestRedactBody_JSONInvalidPassThrough(t *testing.T) {
+	body := `not json { password: "p" `
+	out := RedactBody("application/json", body)
+	if out != body {
+		t.Errorf("invalid JSON should pass through unchanged, got %q", out)
+	}
+}
+
+func TestRedactBody_Form(t *testing.T) {
+	body := "user=alice&password=hunter2&token=xyz&keep=ok"
+	out := RedactBody("application/x-www-form-urlencoded", body)
+	if strings.Contains(out, "hunter2") {
+		t.Errorf("password leaked: %s", out)
+	}
+	if strings.Contains(out, "xyz") {
+		t.Errorf("token leaked: %s", out)
+	}
+	if !strings.Contains(out, "user=alice") {
+		t.Errorf("non-sensitive user field missing: %s", out)
+	}
+	if !strings.Contains(out, "keep=ok") {
+		t.Errorf("non-sensitive keep field missing: %s", out)
+	}
+}
+
+func TestRedactBody_UnknownContentType(t *testing.T) {
+	body := `password=hunter2`
+	out := RedactBody("application/octet-stream", body)
+	if out != body {
+		t.Errorf("unknown content-type should pass through, got %q", out)
+	}
+}
+
+func TestRedactFullDetail_InPlace(t *testing.T) {
+	fd := &FullDetail{
+		RequestHeaders: map[string][]string{
+			"Authorization": {"Bearer live_token_123"},
+			"Content-Type":  {"application/json"},
+		},
+		InjectedHeaders: map[string][]string{
+			"Authorization": {"Bearer injected_credential"},
+		},
+		RequestBody: `{"password":"hunter2","keep":"ok"}`,
+		ResponseHeaders: map[string][]string{
+			"Set-Cookie":   {"session=abc123; Path=/"},
+			"Content-Type": {"application/json"},
+		},
+		ResponseBody: `{"access_token":"leaked","user":"alice"}`,
+	}
+	RedactFullDetail(fd)
+
+	blob, _ := json.Marshal(fd)
+	s := string(blob)
+	for _, secret := range []string{
+		"live_token_123",
+		"injected_credential",
+		"hunter2",
+		"abc123",
+		"leaked",
+	} {
+		if strings.Contains(s, secret) {
+			t.Errorf("secret %q leaked into FullDetail: %s", secret, s)
+		}
+	}
+	if !strings.Contains(s, "alice") {
+		t.Errorf("non-sensitive user field missing from redacted output")
+	}
+}
+
+func TestLogger_AddRedactsFullDetail(t *testing.T) {
+	l := NewLogger(10)
+	e := l.Add(Entry{
+		Method: "POST",
+		Host:   "example.com",
+		Status: "allowed",
+		FullDetail: &FullDetail{
+			RequestHeaders: map[string][]string{"Authorization": {"Bearer xyz"}},
+			RequestBody:    "",
+		},
+	})
+	if got := e.FullDetail.RequestHeaders["Authorization"][0]; got != RedactedPlaceholder {
+		t.Errorf("Authorization not redacted in stored entry: %q", got)
+	}
+	stored, ok := l.GetByID(e.ID)
+	if !ok {
+		t.Fatal("stored entry not found")
+	}
+	if got := stored.FullDetail.RequestHeaders["Authorization"][0]; got != RedactedPlaceholder {
+		t.Errorf("Authorization not redacted when fetched back: %q", got)
+	}
+}
+
+func TestRedactFullDetail_NilSafe(t *testing.T) {
+	RedactFullDetail(nil) // must not panic
+}

--- a/internal/secret/secret.go
+++ b/internal/secret/secret.go
@@ -1,0 +1,215 @@
+// Package secret provides authenticated encryption for sensitive fields
+// that are persisted to state.json (credentials, database passwords, skill
+// tokens, etc.). It uses AES-256-GCM with a master key stored on the
+// persistent partition or supplied via the FIREWALL4AI_MASTER_KEY
+// environment variable.
+//
+// Seal returns an "enc:v1:<base64>" envelope that UnmarshalJSON and JSON
+// readers can treat as a normal string. Open reverses the transform; if the
+// value has no envelope prefix it is returned unchanged so that existing
+// plaintext state.json files continue to load during the migration window.
+// The first subsequent save re-encrypts them.
+package secret
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// envelopePrefix marks a value as ciphertext. v1 = AES-256-GCM, random
+// 12-byte nonce, base64url(no padding) of nonce||ciphertext||tag.
+const envelopePrefix = "enc:v1:"
+
+// masterKeyFile is the filename used to persist the auto-generated key.
+const masterKeyFile = "master.key"
+
+// envVar is consulted first: if set, it must decode as exactly 32 bytes
+// (AES-256) using either hex or base64. This lets operators externalize
+// the key to a TPM unseal or KMS-fetched secret without touching disk.
+const envVar = "FIREWALL4AI_MASTER_KEY"
+
+var (
+	mu    sync.RWMutex
+	aead  cipher.AEAD
+	ready bool
+)
+
+// Init loads or generates the master key and configures the AEAD cipher.
+// It is safe to call multiple times; subsequent calls are no-ops. Returns
+// an error only when the caller supplied an env var that cannot be parsed
+// or when the data directory is not writable. A generated key is written
+// to {dataDir}/master.key with mode 0600.
+func Init(dataDir string) error {
+	mu.Lock()
+	defer mu.Unlock()
+	if ready {
+		return nil
+	}
+
+	key, source, err := loadOrCreateKey(dataDir)
+	if err != nil {
+		return err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return fmt.Errorf("aes cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return fmt.Errorf("gcm: %w", err)
+	}
+	aead = gcm
+	ready = true
+	log.Printf("Master encryption key loaded from %s", source)
+	return nil
+}
+
+// Reset clears the loaded key. Intended for tests.
+func Reset() {
+	mu.Lock()
+	defer mu.Unlock()
+	aead = nil
+	ready = false
+}
+
+// IsSealed reports whether s carries the encryption envelope prefix.
+func IsSealed(s string) bool {
+	return strings.HasPrefix(s, envelopePrefix)
+}
+
+// Seal encrypts plaintext and returns an envelope string. Empty strings
+// pass through unchanged (callers use "" as a no-value sentinel, and we
+// don't want to change that). Values that are already sealed are returned
+// unchanged so the operation is idempotent. If the secret package has not
+// been initialized, plaintext is returned unchanged with a warning logged
+// once — this is the fail-open path for the brief window during startup
+// before Init runs; it should not be reached in production flows.
+func Seal(plaintext string) string {
+	if plaintext == "" {
+		return ""
+	}
+	if IsSealed(plaintext) {
+		return plaintext
+	}
+	mu.RLock()
+	defer mu.RUnlock()
+	if !ready {
+		warnOnce("Seal called before secret.Init; storing plaintext")
+		return plaintext
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		log.Printf("secret.Seal: rand read failed: %v", err)
+		return plaintext
+	}
+	ct := aead.Seal(nil, nonce, []byte(plaintext), nil)
+	buf := make([]byte, 0, len(nonce)+len(ct))
+	buf = append(buf, nonce...)
+	buf = append(buf, ct...)
+	return envelopePrefix + base64.RawStdEncoding.EncodeToString(buf)
+}
+
+// Open reverses Seal. A value without the envelope prefix is returned
+// unchanged (backward compatibility with pre-encryption state.json files).
+// If the envelope is present but decryption fails — typically because a
+// restored backup was encrypted under a different master key — a warning
+// is logged and the empty string is returned. We intentionally return ""
+// rather than the ciphertext to fail closed.
+func Open(s string) string {
+	if !IsSealed(s) {
+		return s
+	}
+	mu.RLock()
+	defer mu.RUnlock()
+	if !ready {
+		warnOnce("Open called before secret.Init; cannot decrypt")
+		return ""
+	}
+	raw, err := base64.RawStdEncoding.DecodeString(strings.TrimPrefix(s, envelopePrefix))
+	if err != nil {
+		log.Printf("secret.Open: base64 decode failed: %v", err)
+		return ""
+	}
+	if len(raw) < aead.NonceSize() {
+		log.Printf("secret.Open: ciphertext too short")
+		return ""
+	}
+	nonce := raw[:aead.NonceSize()]
+	ct := raw[aead.NonceSize():]
+	pt, err := aead.Open(nil, nonce, ct, nil)
+	if err != nil {
+		log.Printf("secret.Open: decrypt failed (key mismatch or tampering?): %v", err)
+		return ""
+	}
+	return string(pt)
+}
+
+func loadOrCreateKey(dataDir string) (key []byte, source string, err error) {
+	if v := strings.TrimSpace(os.Getenv(envVar)); v != "" {
+		k, perr := parseKey(v)
+		if perr != nil {
+			return nil, "", fmt.Errorf("%s: %w", envVar, perr)
+		}
+		return k, "environment variable " + envVar, nil
+	}
+
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return nil, "", fmt.Errorf("create data dir: %w", err)
+	}
+	path := filepath.Join(dataDir, masterKeyFile)
+	if raw, rerr := os.ReadFile(path); rerr == nil {
+		k, perr := parseKey(strings.TrimSpace(string(raw)))
+		if perr != nil {
+			return nil, "", fmt.Errorf("%s: %w", path, perr)
+		}
+		return k, path, nil
+	} else if !os.IsNotExist(rerr) {
+		return nil, "", rerr
+	}
+
+	k := make([]byte, 32)
+	if _, err := rand.Read(k); err != nil {
+		return nil, "", fmt.Errorf("generate master key: %w", err)
+	}
+	encoded := base64.RawStdEncoding.EncodeToString(k) + "\n"
+	if err := os.WriteFile(path, []byte(encoded), 0o600); err != nil {
+		return nil, "", fmt.Errorf("write master key: %w", err)
+	}
+	return k, path + " (newly generated)", nil
+}
+
+func parseKey(s string) ([]byte, error) {
+	if k, err := hex.DecodeString(s); err == nil && len(k) == 32 {
+		return k, nil
+	}
+	if k, err := base64.RawStdEncoding.DecodeString(s); err == nil && len(k) == 32 {
+		return k, nil
+	}
+	if k, err := base64.StdEncoding.DecodeString(s); err == nil && len(k) == 32 {
+		return k, nil
+	}
+	return nil, errors.New("master key must be 32 bytes (hex or base64)")
+}
+
+var warnedMu sync.Mutex
+var warned = map[string]bool{}
+
+func warnOnce(msg string) {
+	warnedMu.Lock()
+	defer warnedMu.Unlock()
+	if warned[msg] {
+		return
+	}
+	warned[msg] = true
+	log.Printf("WARNING: %s", msg)
+}

--- a/internal/secret/secret_test.go
+++ b/internal/secret/secret_test.go
@@ -1,0 +1,162 @@
+package secret
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setup(t *testing.T) string {
+	t.Helper()
+	Reset()
+	os.Unsetenv(envVar)
+	dir := t.TempDir()
+	if err := Init(dir); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	return dir
+}
+
+func TestSealOpen_Roundtrip(t *testing.T) {
+	setup(t)
+	for _, pt := range []string{
+		"hunter2",
+		"",
+		"x",
+		"Bearer eyJhbGciOiJIUzI1NiJ9.abc.xyz",
+		"contains=special&chars;🔒",
+	} {
+		sealed := Seal(pt)
+		if pt == "" {
+			if sealed != "" {
+				t.Errorf("empty input should seal to empty, got %q", sealed)
+			}
+			continue
+		}
+		if !IsSealed(sealed) {
+			t.Errorf("expected envelope prefix on %q, got %q", pt, sealed)
+		}
+		if got := Open(sealed); got != pt {
+			t.Errorf("Open(Seal(%q)) = %q", pt, got)
+		}
+	}
+}
+
+func TestSeal_Idempotent(t *testing.T) {
+	setup(t)
+	first := Seal("p")
+	second := Seal(first)
+	if first != second {
+		t.Errorf("Seal should be idempotent on already-sealed input\n first=%s\nsecond=%s", first, second)
+	}
+}
+
+func TestOpen_PlaintextPassthrough(t *testing.T) {
+	setup(t)
+	if got := Open("not-encrypted"); got != "not-encrypted" {
+		t.Errorf("plaintext should pass through, got %q", got)
+	}
+	if got := Open(""); got != "" {
+		t.Errorf("empty should pass through, got %q", got)
+	}
+}
+
+func TestOpen_WrongKeyReturnsEmpty(t *testing.T) {
+	dir := setup(t)
+	sealed := Seal("p")
+
+	// Rotate the master key: wipe file, re-init.
+	Reset()
+	if err := os.Remove(filepath.Join(dir, masterKeyFile)); err != nil {
+		t.Fatal(err)
+	}
+	if err := Init(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Open(sealed)
+	if got != "" {
+		t.Errorf("Open with rotated key should fail closed to \"\", got %q", got)
+	}
+}
+
+func TestInit_UsesEnvVar(t *testing.T) {
+	Reset()
+	dir := t.TempDir()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	t.Setenv(envVar, base64.RawStdEncoding.EncodeToString(key))
+
+	if err := Init(dir); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	// No master.key file should have been created.
+	if _, err := os.Stat(filepath.Join(dir, masterKeyFile)); !os.IsNotExist(err) {
+		t.Errorf("master.key should not be created when env var is set (err=%v)", err)
+	}
+
+	sealed := Seal("p")
+	if got := Open(sealed); got != "p" {
+		t.Errorf("roundtrip with env-supplied key failed: got %q", got)
+	}
+}
+
+func TestInit_RejectsShortKey(t *testing.T) {
+	Reset()
+	t.Setenv(envVar, base64.RawStdEncoding.EncodeToString([]byte("tooshort")))
+	err := Init(t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for short key")
+	}
+	if !strings.Contains(err.Error(), "32 bytes") {
+		t.Errorf("error should mention 32-byte requirement, got %v", err)
+	}
+}
+
+func TestInit_PersistsGeneratedKey(t *testing.T) {
+	Reset()
+	os.Unsetenv(envVar)
+	dir := t.TempDir()
+	if err := Init(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, masterKeyFile))
+	if err != nil {
+		t.Fatalf("master.key should exist after first Init: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("master.key perms = %o, want 0600", perm)
+	}
+
+	sealed := Seal("p")
+
+	// Reinit from disk, ensure we decrypt the same value.
+	Reset()
+	if err := Init(dir); err != nil {
+		t.Fatal(err)
+	}
+	if got := Open(sealed); got != "p" {
+		t.Errorf("roundtrip across re-Init failed: got %q", got)
+	}
+}
+
+func TestSeal_FailOpenWhenNotInitialized(t *testing.T) {
+	Reset()
+	got := Seal("p")
+	if got != "p" {
+		t.Errorf("Seal before Init should return plaintext unchanged, got %q", got)
+	}
+}
+
+func TestOpen_FailClosedWhenNotInitialized(t *testing.T) {
+	Reset()
+	got := Open("enc:v1:garbage")
+	if got != "" {
+		t.Errorf("Open before Init should return \"\", got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the two P0-priority security issues from the recent code review as separate commits.

### Commit 1 — Log redaction (`3cd4df6`)

Closes #68

- New `internal/logging/redact.go` centralizes header and body redaction.
- `Logger.Add` now redacts every `FullDetail` in place before the entry is appended in memory or persisted to `requests.jsonl`, so sensitive data cannot reach log storage even if a caller forgets to filter.
- Redacted headers: `Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`, `X-Auth-Token`, `X-Access-Token`, `Api-Key` (case-insensitive).
- Redacted body fields (JSON + `application/x-www-form-urlencoded`, nested objects/arrays): `password`, `passwd`, `token`, `secret`, `api_key`, `access_token`, `refresh_token`, `id_token`, `authorization`, `client_secret`, `private_key`.
- Tests: header redaction (positive + negative + case-insensitive + non-mutating copy), JSON/form/unknown body redaction, `Logger.Add` integration test that proves `Authorization` never appears in the stored entry.

### Commit 2 — At-rest secret encryption (`3596086`)

Closes #67

- New `internal/secret` package providing AES-256-GCM `Seal`/`Open` with an `enc:v1:<base64>` envelope.
- Master key is loaded from `FIREWALL4AI_MASTER_KEY` env var (hex or base64, 32 bytes) if set, otherwise from `{DataDir}/master.key` (auto-generated on first boot, `0600` perms).
- `cmd/firewall4ai/state_secrets.go` seals these fields before every save and opens them after load:
  - `auth.Skill.Token`
  - `credentials.Credential.{Password, Token, HeaderValue, ParamValue}`
  - `database.DatabaseConfig.Password`
- Migration: pre-existing plaintext state.json loads unchanged (Open passes through values without the envelope prefix); the next save re-encrypts them.
- `Seal` is idempotent; `Open` fails closed (returns `""`) when a backup is restored under a different master key.
- Tests cover roundtrip, idempotence, plaintext passthrough, key rotation, env-var sourcing, short-key rejection, file persistence & perm check, and fail-open/fail-closed when `Init` has not run.

## Test plan

- [x] `go build ./...` succeeds.
- [x] `go vet ./...` clean.
- [x] `go test ./...` passes — only the pre-existing `internal/dns` `TestHandleForwardReturnsServFail` failure remains, which is unrelated to these changes (confirmed by re-running on the base branch).
- [x] New unit tests: `internal/logging/redact_test.go` (11 cases), `internal/secret/secret_test.go` (8 cases).
- [ ] Manual verification on a running appliance: confirm `state.json` contains `enc:v1:` envelopes after first save, confirm `/api/logs/{id}` responses never contain plaintext `Authorization` values.